### PR TITLE
Add doc type as @role attribute in root element

### DIFF
--- a/xml/concept.xml
+++ b/xml/concept.xml
@@ -33,6 +33,7 @@
  * last modified-->
 
 <article xml:id="concept-example" xml:lang="en"
+ role="concept"
  xmlns="http://docbook.org/ns/docbook" version="5.1"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/xml/reference.xml
+++ b/xml/reference.xml
@@ -33,6 +33,7 @@
  * last modified-->
 
 <article xml:id="reference-example" xml:lang="en"
+ role="reference"
  xmlns="http://docbook.org/ns/docbook" version="5.1"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/xml/task.xml
+++ b/xml/task.xml
@@ -33,6 +33,7 @@
  * last modified-->
  
 <article xml:id="task-example" xml:lang="en"
+ role="task"
  xmlns="http://docbook.org/ns/docbook" version="5.1"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">


### PR DESCRIPTION
Reason: although we may not need it, it can help to programmatically distinguish between different doc types (concept, task, and reference).