### PR TITLE
Add task for setting up UEFI HTTP Boot server

### DIFF
--- a/DC-task-set-up-uefi-http-boot-server
+++ b/DC-task-set-up-uefi-http-boot-server
@@ -1,0 +1,12 @@
+# This file originates from the project https://github.com/openSUSE/doc-kit
+# This file can be edited downstream.
+
+MAIN="task-set-up-uefi-http-boot-server.xml"
+ROOTID="task-set-up-uefi-http-boot-server"
+
+PROFCONDITION="suse-product"
+#PROFCONDITION="suse-product;beta"
+#PROFCONDITION="community-project"
+
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/xml/task-set-up-uefi-http-boot-server.xml
+++ b/xml/task-set-up-uefi-http-boot-server.xml
@@ -53,20 +53,16 @@ https://documentation.suse.com/sles/15-SP3/html/SLES-all/cha-deployment-prep-uef
 
  <section xml:id="introduction-set-up-uefi-http-boot-server">
   <title>Introduction</title>
-  <para><!--TODO improve this intro-->
-   HTTP Boot combines DNS, DHCP, and HTTP to make it possible to boot and
-   deploy systems over the network. HTTP Boot can be used as a high-performance
-   replacement for PXE. HTTP Boot allows to boot a server from a URI over HTTP,
-   quickly transferring large files, such as the Linux kernel and root file
-   system from servers outside of your local network.
+  <para>
+   HTTP Boot can remotely install operating systems from an HTTP URL. While PXE
+   can only deploy images to servers in a local subnet, HTTP Boot can deploy
+   images to servers across different subnets in routed networks, and can
+   quickly transfer larger files, such as the Linux kernel and root file system.
   </para>
   <para>
-   The setup described here uses 192.168.111.0/24 (IPv4) and
-   2001:db8:f00f:cafe::/64 (IPv6) IP subnets and the server IP addresses are
-   192.168.111.1(IPv4) and 2001:db8:f00f:cafe::1/64 (IPv6) as examples. Adjust
-   these values to match your specific setup.
-  </para><!-- Note about manually setting up HTTP repo? -->
-  <!-- With DNS, the firmware and the bootloader can resolve the domain name so it's possible to pass a well-known HTTP URL to download the image across different domains, while tftp (PXE) is only for the local network.-->
+   This article shows you how to configure DNS, DHCP, and HTTP on a single
+   machine to act as an HTTP Boot server.
+  </para>
  </section>
 
  <section xml:id="requirements-set-up-uefi-http-boot-server">
@@ -74,7 +70,7 @@ https://documentation.suse.com/sles/15-SP3/html/SLES-all/cha-deployment-prep-uef
   <itemizedlist>
    <listitem>
     <para>
-     &sles; is installed and up to date.
+     &sles; is installed and up to date on your server.
     </para>
    </listitem>
    <listitem>
@@ -97,18 +93,18 @@ https://documentation.suse.com/sles/15-SP3/html/SLES-all/cha-deployment-prep-uef
   </itemizedlist>
  </section>
 
- <section xml:id="configure-dns-server-set-up-uefi-http-boot-server">
-  <title>Configuring the DNS server (optional)</title>
+ <section xml:id="configure-dns-set-up-uefi-http-boot-server">
+  <title>Configuring the DNS server</title>
   <para>
-   Configuring the DNS server allows you to assign a user-friendly name to the
-   HTTP Boot server.
+   In this procedure, replace the example IP addresses with the appropriate
+   values for your server.
   </para>
   <procedure>
    <step>
     <para>
      Install the <package>dnsmasq</package> package:
     </para>
-<screen>&prompt.root;zypper install dnsmasq</screen>
+<screen>&prompt.user;sudo zypper install dnsmasq</screen>
    </step>
    <step>
     <para>
@@ -120,16 +116,16 @@ addn-hosts=/etc/dnsmasq.d/hosts.conf</screen>
    <step>
     <para>
      Assign a domain name to the IP addresses in the
-     <filename>/etc/dnsmasq.d/hosts.conf</filename> file. For example:
+     <filename>/etc/dnsmasq.d/hosts.conf</filename> file:
     </para>
 <screen>192.168.111.1 www.httpboot.local
 2001:db8:f00f:cafe::1 www.httpboot.local</screen>
    </step>
    <step>
     <para>
-     Start the DNS server:
+     Enable and start the DNS server:
     </para>
- <screen>&prompt.root;systemctl start dnsmasq</screen>
+ <screen>&prompt.user;sudo systemctl enable --now dnsmasq</screen>
    </step>
   </procedure>
   <note>
@@ -142,114 +138,32 @@ addn-hosts=/etc/dnsmasq.d/hosts.conf</screen>
   </note>
  </section>
 
- <section xml:id="configure-dhcp-server-set-up-uefi-http-boot-server">
-  <title>Configuring the DHCP server</title>
-  <para>
-   This procedure uses the IP subnets 192.168.111.0/24 (IPv4) and
-   2001:db8:f00f:cafe::/64 (IPv6), and the server IP addresses
-   192.168.111.1 (IPv4) and 2001:db8:f00f:cafe::1/64 (IPv6).
-   Adjust these values to match your specific setup.
-  </para>
-  <procedure>
-   <step>
-    <para>
-     Install the <package>dhcp-server</package> package:
-    </para>
-<screen>&prompt.root;zypper install dhcp-server</screen>
-   </step>
-   <step>
-    <para>
-     Specify the network interface for the DHCPv4 and DHCPv6 servers
-     in the <filename>/etc/sysconfig/dhcpd</filename> file.
-    </para>
-<screen>DHCPD_INTERFACE="eth0"
-DHCPD6_INTERFACE="eth0"</screen>
-   </step>
-   <step>
-    <para>
-     To set up the DHCPv4 server, edit the <filename>/etc/dhcpd.conf</filename>
-     file to add the following configuration:
-    </para>
-<screen>option domain-name-servers 192.168.111.1;
-option routers 192.168.111.1;
-default-lease-time 14400;
-ddns-update-style none;
-subnet 192.168.111.0 netmask 255.255.255.0 {
-  range dynamic-bootp 192.168.111.100 192.168.111.120;
-  default-lease-time 14400;
-  max-lease-time 172800;
-  option vendor-class-identifier "HTTPClient";
-  filename "http://www.httpboot.local/sle/EFI/BOOT/bootx64.efi";
-}</screen>
-    <para>
-     The vendor class ID must be <literal>HTTPClient</literal>. The client uses
-     this ID to identify an HTTP Boot offer.
-    </para>
-    <para>
-     Something something the boot URL.
-    </para>
-   </step>
-   <step>
-    <para>
-     To set up the DHCPv6 server, edit the <filename>/etc/dhcpd6.conf</filename>
-     file to add the following configuration:
-    </para>
-<screen>option dhcp6.bootfile-url code 59 = string;
-option dhcp6.vendor-class code 16 = {integer 32, integer 16, string};
-subnet6 2001:db8:f00f:cafe::/64 {
-        range6 2001:db8:f00f:cafe::42:10 2001:db8:f00f:cafe::42:99;
-        option dhcp6.bootfile-url "http://www.httpboot.local/sle/EFI/BOOT/bootx64.efi";
-        option dhcp6.name-servers 2001:db8:f00f:cafe::1;
-        option dhcp6.vendor-class 0 10 "HTTPClient";
-}</screen>
-      <para>
-       Something something the boot URL, which must have an IPv6 address.
-      </para>
-      <para>
-       The vendor class option must consist of
-       the enterprise number and the vendor class data (length and the content).
-       Since the HTTP Boot driver ignores the enterprise number, you can set it
-       to <literal>0</literal>. The content of the vendor class data must be
-       <literal>HTTPClient</literal>. The client uses
-       this ID to identify an HTTP Boot offer.
-      </para>
-   </step>
-   <step>
-    <para>
-     Start the DHCP servers:
-    </para>
-<screen>&prompt.root;systemctl enable --now dhcpd
-&prompt.root;systemctl enable --now dhcpd6</screen>
-   </step>
-  </procedure>
- </section>
-
- <section xml:id="configure-http-server-set-up-uefi-http-boot-server">
+ <section xml:id="configure-http-set-up-uefi-http-boot-server">
   <title>Configuring the HTTP server</title>
   <procedure>
    <step>
     <para>
      Install the <package>apache2</package> package:
     </para>
-<screen>&prompt.root;zypper install apache2</screen>
+<screen>&prompt.user;sudo zypper install apache2</screen>
    </step>
    <step>
-    <para><!--Keep here but refer to DHCP section-->
+    <para>
      In the root directory of the HTTP Boot server (<literal>/srv/www/htdocs/</literal>),
      create a subdirectory for the installation content. For example,
      <literal>/srv/www/htdocs/sle/</literal>:
     </para>
-<screen>&prompt.root;mkdir /srv/www/htdocs/sle</screen>
+<screen>&prompt.user;sudo mkdir /srv/www/htdocs/sle</screen>
    </step>
    <step>
-    <para><!-- Must be all files contained in it, not just the .iso file -->
-     Copy or extract the content of the ISO image to the new directory.
+    <para>
+     Copy or extract all of the files from the ISO to the new directory.
     </para>
    </step>
    <step>
     <para>
      To configure the boot menu, edit the
-     <filename>/srv/www/htdocs/sle/EFI/BOOT/grub.cfg</filename> file. Use the
+     <filename>/srv/www/htdocs/sle/EFI/BOOT/grub.cfg</filename> file using the
      following example as a reference:
     </para>
 <screen> menuentry 'Installation IPv4' --class opensuse --class gnu-linux --class gnu --class os {
@@ -272,12 +186,106 @@ subnet6 2001:db8:f00f:cafe::/64 {
     <para>
      Enable and start <literal>apache2</literal>:
     </para>
-<screen>&prompt.root;systemctl enable --now apache2</screen>
+<screen>&prompt.user;sudo systemctl enable --now apache2</screen>
    </step>
   </procedure>
  </section>
 
- <section xml:id="enable-ssl-support-set-up-uefi-http-boot-server">
+ <section xml:id="configure-dhcp-set-up-uefi-http-boot-server">
+  <title>Configuring the DHCP server</title>
+  <para>
+   In this procedure, replace the example IP addresses and subnets with the
+   appropriate values for your system.
+  </para>
+  <procedure>
+   <step>
+    <para>
+     Install the <package>dhcp-server</package> package:
+    </para>
+<screen>&prompt.user;sudo zypper install dhcp-server</screen>
+   </step>
+   <step>
+    <para>
+     Edit the <filename>/etc/sysconfig/dhcpd</filename> file to specify the
+     network interface for the DHCPv4 and DHCPv6 servers:
+    </para>
+<screen>DHCPD_INTERFACE="eth0"
+DHCPD6_INTERFACE="eth0"</screen>
+   </step>
+   <step>
+    <para>
+     To set up the DHCPv4 server, edit the <filename>/etc/dhcpd.conf</filename>
+     file to add the following configuration:
+    </para>
+<screen>option domain-name-servers 192.168.111.1;
+option routers 192.168.111.1;
+default-lease-time 14400;
+ddns-update-style none;
+subnet 192.168.111.0 netmask 255.255.255.0 {
+  range dynamic-bootp 192.168.111.100 192.168.111.120;
+  default-lease-time 14400;
+  max-lease-time 172800;
+  option vendor-class-identifier "HTTPClient"; <co xml:id="co-venclassID-v4"/>
+  filename "http://www.httpboot.local/sle/EFI/BOOT/bootx64.efi"; <co xml:id="co-booturl-v4"/>
+}</screen>
+    <calloutlist>
+     <callout arearefs="co-venclassID-v4">
+      <para>
+       The vendor class ID must be <literal>HTTPClient</literal>. The client uses
+     this ID to identify an HTTP Boot offer.
+      </para>
+     </callout>
+     <callout arearefs="co-booturl-v4">
+      <para>
+       The boot URL must point to the directory you created in
+       <xref linkend="configure-http-set-up-uefi-http-boot-server"/>.
+      </para>
+     </callout>
+    </calloutlist>
+   </step>
+   <step>
+    <para>
+     To set up the DHCPv6 server, edit the <filename>/etc/dhcpd6.conf</filename>
+     file to add the following configuration:
+    </para>
+<screen>option dhcp6.bootfile-url code 59 = string;
+option dhcp6.vendor-class code 16 = {integer 32, integer 16, string};
+subnet6 2001:db8:f00f:cafe::/64 {
+        range6 2001:db8:f00f:cafe::42:10 2001:db8:f00f:cafe::42:99;
+        option dhcp6.bootfile-url "http://www.httpboot.local/sle/EFI/BOOT/bootx64.efi"; <co xml:id="co-booturl-v6"/>
+        option dhcp6.name-servers 2001:db8:f00f:cafe::1;
+        option dhcp6.vendor-class 0 10 "HTTPClient"; <co xml:id="co-venclassID-v6"/>
+}</screen>
+      <calloutlist>
+       <callout arearefs="co-booturl-v6">
+        <para>
+         The boot URL must point to the directory you created in
+         <xref linkend="configure-http-set-up-uefi-http-boot-server"/>.
+        </para>
+       </callout>
+       <callout arearefs="co-venclassID-v6">
+        <para>
+         The vendor class option must consist of the enterprise number, the
+         vendor class length, and the vendor class content. The HTTP Boot driver
+         ignores the enterprise number, so you can set it to <literal>0</literal>.
+         The vendor class length must <literal>10</literal>, and the content
+         must be <literal>HTTPClient</literal>. The client uses this ID
+         to identify an HTTP Boot offer.
+        </para>
+       </callout>
+      </calloutlist>
+   </step>
+   <step>
+    <para>
+     Start the DHCP servers:
+    </para>
+<screen>&prompt.user;sudo systemctl enable --now dhcpd
+&prompt.user;sudo systemctl enable --now dhcpd6</screen>
+   </step>
+  </procedure>
+ </section>
+
+ <section xml:id="enable-ssl-set-up-uefi-http-boot-server">
   <title>Enabling SSL support for the HTTP server (optional)</title>
   <para>
    HTTPS Boot is only supported on &sle; 15 and newer. To use HTTPS Boot, you
@@ -293,7 +301,7 @@ subnet6 2001:db8:f00f:cafe::/64 {
     <para>
      Convert the certificate into the <literal>DER</literal> format:
     </para>
-<screen>&prompt.root;openssl x509 -in <replaceable>CERTIFICATE</replaceable>.crt -outform der -out <replaceable>CERTIFICATE</replaceable>.der</screen>
+<screen>&prompt.user;sudo openssl x509 -in <replaceable>CERTIFICATE</replaceable>.crt -outform der -out <replaceable>CERTIFICATE</replaceable>.der</screen>
    </step>
    <step>
     <para>
@@ -317,27 +325,26 @@ subnet6 2001:db8:f00f:cafe::/64 {
      In the same file, ensure that the <literal>ssl</literal> module appears in
      the <literal>APACHE_MODULES</literal> list:
     </para>
-<screen>&prompt.root;<command>grep 'APACHE_MODULES.*ssl' /etc/sysconfig/apache2</command>
-APACHE_MODULES="actions alias auth_basic authn_core authn_file authz_host
+<screen>&prompt.user;sudo <command>grep 'APACHE_MODULES.*ssl' /etc/sysconfig/apache2</command>
+<emphasis role="bold">APACHE_MODULES</emphasis>="actions alias auth_basic authn_core authn_file authz_host
 authz_groupfile authz_core authz_user autoindex cgi dir env expires include
-log_config mime negotiation setenvif ssl socache_shmcb userdir reqtimeout"</screen>
+log_config mime negotiation setenvif <emphasis role="bold">ssl</emphasis> socache_shmcb userdir reqtimeout"</screen>
    </step>
    <step>
     <para>
      Copy the private key and the certificate to the
      <filename>/etc/apache2/</filename> directory:
     </para>
-<screen>&prompt.root;cp server.key /etc/apache2/ssl.key/
-&prompt.root;chown wwwrun /etc/apache2/ssl.key/server.key
-&prompt.root;chmod 600 /etc/apache2/ssl.key/server.key
-&prompt.root;cp server.crt /etc/apache2/ssl.crt/</screen>
+<screen>&prompt.user;sudo cp server.key /etc/apache2/ssl.key/
+&prompt.user;sudo chown wwwrun /etc/apache2/ssl.key/server.key
+&prompt.user;sudo chmod 600 /etc/apache2/ssl.key/server.key
+&prompt.user;sudo cp server.crt /etc/apache2/ssl.crt/</screen>
    </step>
    <step>
     <para>
      Create the SSL vhost configuration:
     </para>
-<screen>&prompt.root;cd /etc/apache2/vhosts.d
-&prompt.root;cp vhost-ssl.template vhost-ssl.conf</screen>
+<screen>&prompt.user;sudo cp /etc/apache2/vhosts.d/vhost-ssl.template /etc/apache2/vhosts.d/vhost-ssl.conf</screen>
    </step>
    <step>
     <para>
@@ -351,13 +358,13 @@ SSLCertificateKeyFile /etc/apache2/ssl.key/server.key</screen>
     <para>
      Restart Apache to activate the SSL support:
     </para>
-<screen>&prompt.root;systemctl restart apache2</screen>
+<screen>&prompt.user;sudo systemctl restart apache2</screen>
    </step>
    <step>
     <para>
-     Edit the <filename>dhcpd.conf</filename> and <filename>dhcpd6.conf</filename>
-     files to replace the <literal>http://</literal> prefix with
-     <literal>https://</literal>:
+     Replace the <literal>http://</literal> prefix with
+     <literal>https://</literal> in the <filename>/etc/dhcpd.conf</filename>
+     and <filename>/etc/dhcpd6.conf</filename> files:
     </para>
 <screen>filename "http<emphasis role="bold">s</emphasis>://www.httpboot.local/sle/EFI/BOOT/bootx64.efi";</screen>
 <screen>option dhcp6.bootfile-url "http<emphasis role="bold">s</emphasis>://www.httpboot.local/sle/EFI/BOOT/bootx64.efi";</screen>
@@ -366,8 +373,8 @@ SSLCertificateKeyFile /etc/apache2/ssl.key/server.key</screen>
     <para>
      Restart the DHCP servers:
     </para>
-<screen>&prompt.root;systemctl restart dhcpd
-&prompt.root;systemctl restart dhcpd6</screen>
+<screen>&prompt.user;sudo systemctl restart dhcpd
+&prompt.user;sudo systemctl restart dhcpd6</screen>
    </step>
   </procedure>
  </section>
@@ -375,13 +382,9 @@ SSLCertificateKeyFile /etc/apache2/ssl.key/server.key</screen>
  <section xml:id="summary-set-up-uefi-http-boot-server">
   <title>Summary</title>
   <para>
-   You can now use this server to boot client machines over HTTP, if the client
-   firmware supports HTTP Boot.
-  </para>
-  <para>
-   Enabling HTTP Boot on a physical client machine depends on your specific
-   hardware. Consult the relevant documentation for information on how to
-   enable HTTP Boot on your particular machine.
+   You can now use this server to remotely install operating systems from an
+   HTTP URL, if the client firmware supports HTTP Boot. Consult the relevant
+   documentation for information on how to enable HTTP Boot on client machines.
   </para>
  </section>
 
@@ -408,22 +411,22 @@ SSLCertificateKeyFile /etc/apache2/ssl.key/server.key</screen>
   <itemizedlist>
    <listitem>
     <para>
-     Installing UEFI support (on VMs)
+     Installing UEFI support (VMs)
     </para>
    </listitem>
    <listitem>
     <para>
-     Guest installation
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     Booting the installation system
+     Guest installation (VMs)
     </para>
    </listitem>
    <listitem>
     <para>
      Remote installation
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Booting the installation system
     </para>
    </listitem>
   </itemizedlist>

--- a/xml/task-set-up-uefi-http-boot-server.xml
+++ b/xml/task-set-up-uefi-http-boot-server.xml
@@ -96,7 +96,7 @@ https://documentation.suse.com/sles/15-SP3/html/SLES-all/cha-deployment-prep-uef
  <section xml:id="configure-dns-set-up-uefi-http-boot-server">
   <title>Configuring the DNS server</title>
   <para>
-   In this procedure, replace the example IP addresses with the appropriate
+   In this procedure, replace the example host names and IP addresses with the appropriate
    values for your server.
   </para>
   <procedure>

--- a/xml/task-set-up-uefi-http-boot-server.xml
+++ b/xml/task-set-up-uefi-http-boot-server.xml
@@ -117,8 +117,8 @@ addn-hosts=/etc/hosts.conf</screen>
      Assign a domain name to the IP addresses in the
      <filename>/etc/hosts.conf</filename> file:
     </para>
-<screen>192.168.111.1 www.httpboot.local
-2001:db8:f00f:cafe::1 www.httpboot.local</screen>
+<screen><replaceable>192.168.111.1 www.httpboot.local
+2001:db8:f00f:cafe::1 www.httpboot.local</replaceable></screen>
    </step>
    <step>
     <para>
@@ -213,8 +213,8 @@ DHCPD6_INTERFACE="eth0"</screen>
    </step>
    <step>
     <para>
-     To set up the DHCPv4 server, edit the <filename>/etc/dhcpd.conf</filename>
-     file to add the following configuration:
+     To configure the DHCPv4 server, edit the <filename>/etc/dhcpd.conf</filename>
+     file using the following example as a reference:
     </para>
 <screen>option domain-name-servers 192.168.111.1;
 option routers 192.168.111.1;
@@ -244,8 +244,8 @@ subnet 192.168.111.0 netmask 255.255.255.0 {
    </step>
    <step>
     <para>
-     To set up the DHCPv6 server, edit the <filename>/etc/dhcpd6.conf</filename>
-     file to add the following configuration:
+     To configure the DHCPv6 server, edit the <filename>/etc/dhcpd6.conf</filename>
+     file using the following example as a reference:
     </para>
 <screen>option dhcp6.bootfile-url code 59 = string;
 option dhcp6.vendor-class code 16 = {integer 32, integer 16, string};

--- a/xml/task-set-up-uefi-http-boot-server.xml
+++ b/xml/task-set-up-uefi-http-boot-server.xml
@@ -53,50 +53,51 @@ https://documentation.suse.com/sles/15-SP3/html/SLES-all/cha-deployment-prep-uef
 
  <section xml:id="introduction-set-up-uefi-http-boot-server">
   <title>Introduction</title>
-   <para><!--TODO improve this intro-->
-    HTTP Boot combines DNS, DHCP, and HTTP to make it possible to boot and
-    deploy systems over the network. HTTP Boot can be used as a high-performance
-    replacement for PXE. HTTP Boot allows to boot a server from a URI over HTTP,
-    quickly transferring large files, such as the Linux kernel and root file
-    system from servers outside of your local network.
-   </para>
+  <para><!--TODO improve this intro-->
+   HTTP Boot combines DNS, DHCP, and HTTP to make it possible to boot and
+   deploy systems over the network. HTTP Boot can be used as a high-performance
+   replacement for PXE. HTTP Boot allows to boot a server from a URI over HTTP,
+   quickly transferring large files, such as the Linux kernel and root file
+   system from servers outside of your local network.
+  </para>
+  <para>
+   The setup described here uses 192.168.111.0/24 (IPv4) and
+   2001:db8:f00f:cafe::/64 (IPv6) IP subnets and the server IP addresses are
+   192.168.111.1(IPv4) and 2001:db8:f00f:cafe::1/64 (IPv6) as examples. Adjust
+   these values to match your specific setup.
+  </para><!-- Note about manually setting up HTTP repo? -->
+  <!-- With DNS, the firmware and the bootloader can resolve the domain name so it's possible to pass a well-known HTTP URL to download the image across different domains, while tftp (PXE) is only for the local network.-->
  </section>
 
  <section xml:id="requirements-set-up-uefi-http-boot-server">
   <title>Requirements</title>
-  <itemizedlist><!-- TODO Make proper sentences -->
+  <itemizedlist>
    <listitem>
     <para>
-     The setup described here uses 192.168.111.0/24 (IPv4) and
-     2001:db8:f00f:cafe::/64 (IPv6) IP subnets and the server IP addresses are
-     192.168.111.1(IPv4) and 2001:db8:f00f:cafe::1/64 (IPv6) as examples. Adjust
-     these values to match your specific setup.
+     &sles; is installed and up to date.
     </para>
    </listitem>
    <listitem>
     <para>
-     &sle; installed and up to date
+     Networking is configured on your server.
     </para>
    </listitem>
    <listitem>
     <para>
-     Network configured
+     You have a &sles; ISO image available, either on a media drive or downloaded
+     on your server.
     </para>
    </listitem>
    <listitem>
     <para>
-     ISO available
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     SSL certificate on server?
+     If you want to enable SSL support, you must have an SSL certificate
+     installed on your server.
     </para>
    </listitem>
   </itemizedlist>
  </section>
 
- <section xml:id="configure-dns-server">
+ <section xml:id="configure-dns-server-set-up-uefi-http-boot-server">
   <title>Configuring the DNS server (optional)</title>
   <para>
    Configuring the DNS server allows you to assign a user-friendly name to the
@@ -141,10 +142,13 @@ addn-hosts=/etc/dnsmasq.d/hosts.conf</screen>
   </note>
  </section>
 
- <section xml:id="configure-dhcp-server">
+ <section xml:id="configure-dhcp-server-set-up-uefi-http-boot-server">
   <title>Configuring the DHCP server</title>
   <para>
-   This procedure configures DHCPv4 and DHCPv6 for both HTTP Boot and PXE Boot.
+   This procedure uses the IP subnets 192.168.111.0/24 (IPv4) and
+   2001:db8:f00f:cafe::/64 (IPv6), and the server IP addresses
+   192.168.111.1 (IPv4) and 2001:db8:f00f:cafe::1/64 (IPv6).
+   Adjust these values to match your specific setup.
   </para>
   <procedure>
    <step>
@@ -156,15 +160,15 @@ addn-hosts=/etc/dnsmasq.d/hosts.conf</screen>
    <step>
     <para>
      Specify the network interface for the DHCPv4 and DHCPv6 servers
-     in the <filename>/etc/sysconfig/dhcpd</filename> file:
+     in the <filename>/etc/sysconfig/dhcpd</filename> file.
     </para>
 <screen>DHCPD_INTERFACE="eth0"
 DHCPD6_INTERFACE="eth0"</screen>
    </step>
    <step>
     <para>
-     To set up a DHCPv4 server for both PXE Boot and HTTP Boot, add the
-    following configuration to the <filename>/etc/dhcpd.conf</filename> file:
+     To set up the DHCPv4 server, edit the <filename>/etc/dhcpd.conf</filename>
+     file to add the following configuration:
     </para>
 <screen>option domain-name-servers 192.168.111.1;
 option routers 192.168.111.1;
@@ -174,27 +178,21 @@ subnet 192.168.111.0 netmask 255.255.255.0 {
   range dynamic-bootp 192.168.111.100 192.168.111.120;
   default-lease-time 14400;
   max-lease-time 172800;
-  class "pxeclients"{
-    match if substring (option vendor-class-identifier, 0, 9) = "PXEClient";
-    next-server 192.168.111.1;
-    filename "/bootx64.efi";
-  }
-  class "httpclients" {
-    match if substring (option vendor-class-identifier, 0, 10) = "HTTPClient";
-    option vendor-class-identifier "HTTPClient";
-    filename "http://www.httpboot.local/sle/EFI/BOOT/bootx64.efi";
-  }
+  option vendor-class-identifier "HTTPClient";
+  filename "http://www.httpboot.local/sle/EFI/BOOT/bootx64.efi";
 }</screen>
     <para>
-     Note that the DHCPv4 server must use the <literal>HTTPClient</literal>
-     parameter for the vendor class ID, as the client uses it to identify an
-     HTTP Boot offer.
+     The vendor class ID must be <literal>HTTPClient</literal>. The client uses
+     this ID to identify an HTTP Boot offer.
+    </para>
+    <para>
+     Something something the boot URL.
     </para>
    </step>
    <step>
     <para>
-     To set up the DHCPv6 server, add the following configuration to
-    <filename>/etc/dhcpd6.conf</filename>:
+     To set up the DHCPv6 server, edit the <filename>/etc/dhcpd6.conf</filename>
+     file to add the following configuration:
     </para>
 <screen>option dhcp6.bootfile-url code 59 = string;
 option dhcp6.vendor-class code 16 = {integer 32, integer 16, string};
@@ -204,54 +202,17 @@ subnet6 2001:db8:f00f:cafe::/64 {
         option dhcp6.name-servers 2001:db8:f00f:cafe::1;
         option dhcp6.vendor-class 0 10 "HTTPClient";
 }</screen>
-    <para>
-     This configuration defines the type of the boot URL, the vendor class, and
-     other required options. Similar to the DHCPv4 settings, it is necessary to
-     provide the boot URL, which must have an IPv6 address. It is also
-     necessary to specify the vendor class option. In DHCPv6, it consists of
-     the enterprise number and the vendor class data (length and the content).
-     Since the HTTP Boot driver ignores the enterprise number, you can set it
-     to <literal>0</literal>. The content of the vendor class data needs to be
-     <literal>HTTPClient</literal>; otherwise, the client ignores the offer.
-    </para>
-    <para>
-     Using the following configuration, it is possible to configure the DHCPv6
-     server for both PXE Boot and HTTP Boot:
-    </para>
-<screen>option dhcp6.bootfile-url code 59 = string;
-option dhcp6.vendor-class code 16 = {integer 32, integer 16, string};
-
-subnet6 2001:db8:f00f:cafe::/64 {
-        range6 2001:db8:f00f:cafe::42:10 2001:db8:f00f:cafe::42:99;
-
-        class "PXEClient" {
-                match substring (option dhcp6.vendor-class, 6, 9);
-        }
-
-        subclass "PXEClient" "PXEClient" {
-                option dhcp6.bootfile-url "tftp://[2001:db8:f00f:cafe::1]/bootloader.efi";
-        }
-
-        class "HTTPClient"; {
-                match substring (option dhcp6.vendor-class, 6, 10);
-        }
-
-        subclass "HTTPClient" "HTTPClient" {
-                option dhcp6.bootfile-url "http://www.httpboot.local/sle/EFI/BOOT/bootx64.efi";
-                option dhcp6.name-servers 2001:db8:f00f:cafe::1;
-                option dhcp6.vendor-class 0 10 "HTTPClient";
-        }
- }</screen>
-    <para>
-     You can also match the vendor class to a specific architecture by changing
-     the following line:
-    </para>
-<screen>        subclass "HTTPClient" "HTTPClient":Arch:00016 {</screen>
-    <para>
-     In this example, <literal>HTTPClient:Arch:00016</literal> refers to an
-     &x86-64; HTTP Boot client. This configuration allows the server to serve
-     different architectures simultaneously.
-    </para>
+      <para>
+       Something something the boot URL, which must have an IPv6 address.
+      </para>
+      <para>
+       The vendor class option must consist of
+       the enterprise number and the vendor class data (length and the content).
+       Since the HTTP Boot driver ignores the enterprise number, you can set it
+       to <literal>0</literal>. The content of the vendor class data must be
+       <literal>HTTPClient</literal>. The client uses
+       this ID to identify an HTTP Boot offer.
+      </para>
    </step>
    <step>
     <para>
@@ -263,54 +224,7 @@ subnet6 2001:db8:f00f:cafe::/64 {
   </procedure>
  </section>
 
- <section xml:id="configure-tftp-server">
-  <title>Configuring the TFTP server (optional)</title>
-  <para>
-   You must configure a TFTP server if you want to use both PXE Boot and HTTP Boot.
-  </para>
-  <procedure>
-   <step>
-    <para>
-     Install the <package>tftp</package> package:
-    </para>
-<screen>&prompt.root;zypper install tftp</screen>
-   </step>
-   <step>
-    <para>
-     Enable and start the TFTP service:
-    </para>
-<screen>&prompt.root;systemctl enable --now tftp.socket
-&prompt.root;systemctl enable --now tftp.service</screen>
-   </step>
-   <step>
-    <para>
-     List the available <package>tftpboot-installation</package> packages:
-    </para>
-<screen>&prompt.root;zypper se tftpboot</screen>
-   </step>
-   <step>
-    <para>
-     Install the appropriate package for your version and architecture.
-     For example:
-    </para>
-<screen>&prompt.root;zypper install tftpboot-installation-SLE-15-SP3-x86_64</screen>
-   </step>
-   <step>
-    <para>
-     Copy the content of the
-     <filename>SLE-<replaceable>VERSION</replaceable>-<replaceable>ARCH</replaceable></filename>
-     directory to the root directory of the TFTP server. For example:
-    </para>
-<screen>&prompt.root;cp -r /usr/share/tftpboot-installation/SLE-15-SP3-x86_64 /srv/tftpboot</screen>
-   </step>
-  </procedure>
-  <para>
-   For more information, see
-   <filename>/usr/share/tftpboot-installation/SLE-<replaceable>VERSION</replaceable>-<replaceable>ARCH</replaceable>/README</filename>.
-  </para>
- </section>
-
- <section xml:id="httpboot-http-server">
+ <section xml:id="configure-http-server-set-up-uefi-http-boot-server">
   <title>Configuring the HTTP server</title>
   <procedure>
    <step>
@@ -320,18 +234,16 @@ subnet6 2001:db8:f00f:cafe::/64 {
 <screen>&prompt.root;zypper install apache2</screen>
    </step>
    <step>
-    <para>
-     In the HTTP boot server directory (<literal>/srv/www/htdocs/</literal>),
+    <para><!--Keep here but refer to DHCP section-->
+     In the root directory of the HTTP Boot server (<literal>/srv/www/htdocs/</literal>),
      create a subdirectory for the installation content. For example,
      <literal>/srv/www/htdocs/sle/</literal>:
     </para>
-<screen>&prompt.user;cd /srv/www/htdocs
-&prompt.user;mkdir sle</screen>
+<screen>&prompt.root;mkdir /srv/www/htdocs/sle</screen>
    </step>
    <step>
-    <para>
-     Copy all of the contents of the ISO image to the
-     <literal>/srv/www/htdocs/sle/</literal> directory.
+    <para><!-- Must be all files contained in it, not just the .iso file -->
+     Copy or extract the content of the ISO image to the new directory.
     </para>
    </step>
    <step>
@@ -365,49 +277,50 @@ subnet6 2001:db8:f00f:cafe::/64 {
   </procedure>
  </section>
 
- <section xml:id="httpboot-http-server-ssl-support">
+ <section xml:id="enable-ssl-support-set-up-uefi-http-boot-server">
   <title>Enabling SSL support for the HTTP server (optional)</title>
   <para>
-   HTTPS Boot is only supported on &sle; 15 and newer. To use HTTPS Boot, you must convert an existing server certificate
-   into the <literal>DER</literal> format and enroll it into the client's
-   firmware.
+   HTTPS Boot is only supported on &sle; 15 and newer. To use HTTPS Boot, you
+   must convert an SSL certificate into the <literal>DER</literal>
+   format and enroll it into the client's firmware.
+  </para>
+  <para>
+   This procedure assumes that you already have an SSL certificate installed on
+   your server.
   </para>
   <procedure>
    <step>
     <para>
-     Assuming you already have a certificate installed on your server, convert
-     it into the <literal>DER</literal> format for use with the client:
+     Convert the certificate into the <literal>DER</literal> format:
     </para>
-<screen>&prompt.root;openssl x509 -in <replaceable>CERTIFICATE</replaceable>.crt \
--outform der -out <replaceable>CERTIFICATE</replaceable>.der</screen>
+<screen>&prompt.root;openssl x509 -in <replaceable>CERTIFICATE</replaceable>.crt -outform der -out <replaceable>CERTIFICATE</replaceable>.der</screen>
    </step>
    <step>
     <para>
-     Enroll the server certificate into the client firmware.
-    </para>
-    <para>
-     The exact procedure for enrolling the converted certificate depends on the
-     specific implementation of the client's firmware. For certain hardware,
-     you must enroll the certificate manually via the firmware UI using an
-     external storage device with the certificate on it. Machines with Redfish
-     support can enroll the certificate remotely. Consult the documentation for
-     your specific hardware for more information on enrolling certificates.
+     Enroll the server certificate into the client firmware. The procedure
+     for enrolling the converted certificate depends on the client. For some
+     hardware, you must enroll the certificate manually using an external
+     storage device with the certificate on it. For machines with Redfish
+     support, you can enroll the certificate remotely. Consult the
+     documentation for your specific client for more information on
+     enrolling certificates.
     </para>
    </step>
    <step>
     <para>
-     Add the SSL flag to the <filename>/etc/sysconfig/apache2</filename> file:
+     Edit the <filename>/etc/sysconfig/apache2</filename> file to add the SSL flag:
     </para>
 <screen>APACHE_SERVER_FLAGS="SSL"</screen>
    </step>
    <step>
     <para>
-     In the same file, ensure that the <literal>ssl</literal> module is listed in
-     <literal>APACHE_MODULES</literal>. For example:
+     In the same file, ensure that the <literal>ssl</literal> module appears in
+     the <literal>APACHE_MODULES</literal> list:
     </para>
-<screen>APACHE_MODULES="actions alias auth_basic authn_file authz_host authz_groupfile authz_core
-authz_user autoindex cgi dir env expires include log_config mime negotiation setenvif <emphasis role="bold">ssl</emphasis>
-socache_shmcb userdir reqtimeout authn_core headers proxy proxy_http proxy_wstunnel"</screen>
+<screen>&prompt.root;<command>grep 'APACHE_MODULES.*ssl' /etc/sysconfig/apache2</command>
+APACHE_MODULES="actions alias auth_basic authn_core authn_file authz_host
+authz_groupfile authz_core authz_user autoindex cgi dir env expires include
+log_config mime negotiation setenvif ssl socache_shmcb userdir reqtimeout"</screen>
    </step>
    <step>
     <para>
@@ -428,9 +341,8 @@ socache_shmcb userdir reqtimeout authn_core headers proxy proxy_http proxy_wstun
    </step>
    <step>
     <para>
-     Change the private key and the certificate in the
-     <filename>/etc/apache2/vhosts.d/vhost-ssl.conf</filename>
-     file to the following values:
+     Edit the <filename>/etc/apache2/vhosts.d/vhost-ssl.conf</filename> file to
+     change the private key and the certificate to the following values:
     </para>
 <screen>SSLCertificateFile /etc/apache2/ssl.crt/server.crt
 SSLCertificateKeyFile /etc/apache2/ssl.key/server.key</screen>
@@ -443,14 +355,16 @@ SSLCertificateKeyFile /etc/apache2/ssl.key/server.key</screen>
    </step>
    <step>
     <para>
-     Replace the <literal>http://</literal> prefix with
-     <literal>https://</literal> in <filename>dhcpd.conf</filename>
-     and <filename>dhcpd6.conf</filename>.
+     Edit the <filename>dhcpd.conf</filename> and <filename>dhcpd6.conf</filename>
+     files to replace the <literal>http://</literal> prefix with
+     <literal>https://</literal>:
     </para>
+<screen>filename "http<emphasis role="bold">s</emphasis>://www.httpboot.local/sle/EFI/BOOT/bootx64.efi";</screen>
+<screen>option dhcp6.bootfile-url "http<emphasis role="bold">s</emphasis>://www.httpboot.local/sle/EFI/BOOT/bootx64.efi";</screen>
    </step>
    <step>
     <para>
-     Restart the DHCP server:
+     Restart the DHCP servers:
     </para>
 <screen>&prompt.root;systemctl restart dhcpd
 &prompt.root;systemctl restart dhcpd6</screen>
@@ -460,14 +374,14 @@ SSLCertificateKeyFile /etc/apache2/ssl.key/server.key</screen>
 
  <section xml:id="summary-set-up-uefi-http-boot-server">
   <title>Summary</title>
-  <para><!-- TODO Expand and improve -->
-   Enabling HTTP Boot on a physical client machine depends on your specific
-   hardware. Consult the documentation for further information on how to
-   enable HTTP Boot on your particular machine.
+  <para>
+   You can now use this server to boot client machines over HTTP, if the client
+   firmware supports HTTP Boot.
   </para>
   <para>
-   If the firmware already supports HTTP boot, plug in the cable and choose the
-   correct boot option.
+   Enabling HTTP Boot on a physical client machine depends on your specific
+   hardware. Consult the relevant documentation for information on how to
+   enable HTTP Boot on your particular machine.
   </para>
  </section>
 
@@ -475,7 +389,7 @@ SSLCertificateKeyFile /etc/apache2/ssl.key/server.key</screen>
   <title>Troubleshooting</title>
   <variablelist>
    <varlistentry>
-    <term>Problem phrased as question</term>
+    <term>RP filter dropping DHCPv6 packets</term>
     <listitem>
      <para>
       If DHCPv6 packets are dropped by the RP filter in the firewall, check its
@@ -486,14 +400,6 @@ SSLCertificateKeyFile /etc/apache2/ssl.key/server.key</screen>
      <screen>IPv6_rpfilter=no</screen>
     </listitem>
    </varlistentry>
-   <varlistentry>
-    <term>Another problem phrased as question</term>
-    <listitem>
-     <para>
-      Another paragraph of text.
-     </para>
-    </listitem>
-   </varlistentry>
   </variablelist>
  </section>
 
@@ -502,17 +408,22 @@ SSLCertificateKeyFile /etc/apache2/ssl.key/server.key</screen>
   <itemizedlist>
    <listitem>
     <para>
-     An
+     Installing UEFI support (on VMs)
     </para>
    </listitem>
    <listitem>
     <para>
-     Unordered
+     Guest installation
     </para>
    </listitem>
    <listitem>
     <para>
-     List
+     Booting the installation system
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Remote installation
     </para>
    </listitem>
   </itemizedlist>
@@ -528,12 +439,12 @@ SSLCertificateKeyFile /etc/apache2/ssl.key/server.key</screen>
    </listitem>
    <listitem>
     <para>
-     Unordered
+     Customizing installation images
     </para>
    </listitem>
    <listitem>
     <para>
-     List
+     Setting up a network installation source
     </para>
    </listitem>
   </itemizedlist>

--- a/xml/task-set-up-uefi-http-boot-server.xml
+++ b/xml/task-set-up-uefi-http-boot-server.xml
@@ -1,0 +1,541 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This file originates from the project https://github.com/openSUSE/doc-kit -->
+<!-- This file can be edited downstream. -->
+
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+ type="text/xml"
+ title="Profiling step"?>
+<!DOCTYPE article
+[
+  <!ENTITY % entities SYSTEM "generic-entities.ent">
+    %entities;
+]>
+
+<!--metadata
+ * product SLES
+ * product version xyz
+ * topic category/ies network, installation
+ * target group(s) system administrators
+ * initially published
+ * last modified-->
+
+<!-- Based on uefi-httpboot-server.xml
+https://documentation.suse.com/sles/15-SP3/html/SLES-all/cha-deployment-prep-uefi-httpboot.html-->
+
+<article xml:id="task-set-up-uefi-http-boot-server" xml:lang="en"
+ role="task"
+ xmlns="http://docbook.org/ns/docbook" version="5.1"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink">
+
+ <info>
+   <title>Setting up a UEFI HTTP Boot server</title>
+   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+    <dm:bugtracker>
+     <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
+     <dm:component>Documentation</dm:component>
+     <dm:product>Product Name</dm:product>
+     <dm:assignee>assignee@suse.com</dm:assignee>
+    </dm:bugtracker>
+    <dm:translation>no</dm:translation>
+   </dm:docmanager>
+ </info>
+
+<section xml:id="environment-set-up-uefi-http-boot-server">
+ <title>Environment</title>
+  <para>This document applies to the following products and product versions:</para>
+  <itemizedlist>
+  <listitem>
+   <para>&sles;&nbsp;15&nbsp;SP3, 15&nbsp;SP2, 15&nbsp;SP1, 15&nbsp;GA, 12&nbsp;SP5, 12&nbsp;SP4, 12&nbsp;SP3</para>
+  </listitem>
+ </itemizedlist>
+</section>
+
+ <section xml:id="introduction-set-up-uefi-http-boot-server">
+  <title>Introduction</title>
+   <para><!--TODO improve this intro-->
+    HTTP Boot combines DNS, DHCP, and HTTP to make it possible to boot and
+    deploy systems over the network. HTTP Boot can be used as a high-performance
+    replacement for PXE. HTTP Boot allows to boot a server from a URI over HTTP,
+    quickly transferring large files, such as the Linux kernel and root file
+    system from servers outside of your local network.
+   </para>
+ </section>
+
+ <section xml:id="requirements-set-up-uefi-http-boot-server">
+  <title>Requirements</title>
+  <itemizedlist><!-- TODO Make proper sentences -->
+   <listitem>
+    <para>
+     The setup described here uses 192.168.111.0/24 (IPv4) and
+     2001:db8:f00f:cafe::/64 (IPv6) IP subnets and the server IP addresses are
+     192.168.111.1(IPv4) and 2001:db8:f00f:cafe::1/64 (IPv6) as examples. Adjust
+     these values to match your specific setup.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     &sle; installed and up to date
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Network configured
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     ISO available
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     SSL certificate on server?
+    </para>
+   </listitem>
+  </itemizedlist>
+ </section>
+
+ <section xml:id="configure-dns-server">
+  <title>Configuring the DNS server (optional)</title>
+  <para>
+   Configuring the DNS server allows you to assign a user-friendly name to the
+   HTTP Boot server.
+  </para>
+  <procedure>
+   <step>
+    <para>
+     Install the <package>dnsmasq</package> package:
+    </para>
+<screen>&prompt.root;zypper install dnsmasq</screen>
+   </step>
+   <step>
+    <para>
+     Add the following lines to the <filename>/etc/dnsmasq.conf</filename> file:
+    </para>
+<screen>interface=eth0
+addn-hosts=/etc/dnsmasq.d/hosts.conf</screen>
+   </step>
+   <step>
+    <para>
+     Assign a domain name to the IP addresses in the
+     <filename>/etc/dnsmasq.d/hosts.conf</filename> file. For example:
+    </para>
+<screen>192.168.111.1 www.httpboot.local
+2001:db8:f00f:cafe::1 www.httpboot.local</screen>
+   </step>
+   <step>
+    <para>
+     Start the DNS server:
+    </para>
+ <screen>&prompt.root;systemctl start dnsmasq</screen>
+   </step>
+  </procedure>
+  <note>
+   <title>Use the <phrase role="productname">shim</phrase> boot loader</title>
+   <para>
+    Because of a change in UEFI 2.7, we recommend using a shim boot loader from
+    &sle; 15 or newer to avoid potential errors caused by the additional DNS
+    node.
+   </para>
+  </note>
+ </section>
+
+ <section xml:id="configure-dhcp-server">
+  <title>Configuring the DHCP server</title>
+  <para>
+   This procedure configures DHCPv4 and DHCPv6 for both HTTP Boot and PXE Boot.
+  </para>
+  <procedure>
+   <step>
+    <para>
+     Install the <package>dhcp-server</package> package:
+    </para>
+<screen>&prompt.root;zypper install dhcp-server</screen>
+   </step>
+   <step>
+    <para>
+     Specify the network interface for the DHCPv4 and DHCPv6 servers
+     in the <filename>/etc/sysconfig/dhcpd</filename> file:
+    </para>
+<screen>DHCPD_INTERFACE="eth0"
+DHCPD6_INTERFACE="eth0"</screen>
+   </step>
+   <step>
+    <para>
+     To set up a DHCPv4 server for both PXE Boot and HTTP Boot, add the
+    following configuration to the <filename>/etc/dhcpd.conf</filename> file:
+    </para>
+<screen>option domain-name-servers 192.168.111.1;
+option routers 192.168.111.1;
+default-lease-time 14400;
+ddns-update-style none;
+subnet 192.168.111.0 netmask 255.255.255.0 {
+  range dynamic-bootp 192.168.111.100 192.168.111.120;
+  default-lease-time 14400;
+  max-lease-time 172800;
+  class "pxeclients"{
+    match if substring (option vendor-class-identifier, 0, 9) = "PXEClient";
+    next-server 192.168.111.1;
+    filename "/bootx64.efi";
+  }
+  class "httpclients" {
+    match if substring (option vendor-class-identifier, 0, 10) = "HTTPClient";
+    option vendor-class-identifier "HTTPClient";
+    filename "http://www.httpboot.local/sle/EFI/BOOT/bootx64.efi";
+  }
+}</screen>
+    <para>
+     Note that the DHCPv4 server must use the <literal>HTTPClient</literal>
+     parameter for the vendor class ID, as the client uses it to identify an
+     HTTP Boot offer.
+    </para>
+   </step>
+   <step>
+    <para>
+     To set up the DHCPv6 server, add the following configuration to
+    <filename>/etc/dhcpd6.conf</filename>:
+    </para>
+<screen>option dhcp6.bootfile-url code 59 = string;
+option dhcp6.vendor-class code 16 = {integer 32, integer 16, string};
+subnet6 2001:db8:f00f:cafe::/64 {
+        range6 2001:db8:f00f:cafe::42:10 2001:db8:f00f:cafe::42:99;
+        option dhcp6.bootfile-url "http://www.httpboot.local/sle/EFI/BOOT/bootx64.efi";
+        option dhcp6.name-servers 2001:db8:f00f:cafe::1;
+        option dhcp6.vendor-class 0 10 "HTTPClient";
+}</screen>
+    <para>
+     This configuration defines the type of the boot URL, the vendor class, and
+     other required options. Similar to the DHCPv4 settings, it is necessary to
+     provide the boot URL, which must have an IPv6 address. It is also
+     necessary to specify the vendor class option. In DHCPv6, it consists of
+     the enterprise number and the vendor class data (length and the content).
+     Since the HTTP Boot driver ignores the enterprise number, you can set it
+     to <literal>0</literal>. The content of the vendor class data needs to be
+     <literal>HTTPClient</literal>; otherwise, the client ignores the offer.
+    </para>
+    <para>
+     Using the following configuration, it is possible to configure the DHCPv6
+     server for both PXE Boot and HTTP Boot:
+    </para>
+<screen>option dhcp6.bootfile-url code 59 = string;
+option dhcp6.vendor-class code 16 = {integer 32, integer 16, string};
+
+subnet6 2001:db8:f00f:cafe::/64 {
+        range6 2001:db8:f00f:cafe::42:10 2001:db8:f00f:cafe::42:99;
+
+        class "PXEClient" {
+                match substring (option dhcp6.vendor-class, 6, 9);
+        }
+
+        subclass "PXEClient" "PXEClient" {
+                option dhcp6.bootfile-url "tftp://[2001:db8:f00f:cafe::1]/bootloader.efi";
+        }
+
+        class "HTTPClient"; {
+                match substring (option dhcp6.vendor-class, 6, 10);
+        }
+
+        subclass "HTTPClient" "HTTPClient" {
+                option dhcp6.bootfile-url "http://www.httpboot.local/sle/EFI/BOOT/bootx64.efi";
+                option dhcp6.name-servers 2001:db8:f00f:cafe::1;
+                option dhcp6.vendor-class 0 10 "HTTPClient";
+        }
+ }</screen>
+    <para>
+     You can also match the vendor class to a specific architecture by changing
+     the following line:
+    </para>
+<screen>        subclass "HTTPClient" "HTTPClient":Arch:00016 {</screen>
+    <para>
+     In this example, <literal>HTTPClient:Arch:00016</literal> refers to an
+     &x86-64; HTTP Boot client. This configuration allows the server to serve
+     different architectures simultaneously.
+    </para>
+   </step>
+   <step>
+    <para>
+     Start the DHCP servers:
+    </para>
+<screen>&prompt.root;systemctl enable --now dhcpd
+&prompt.root;systemctl enable --now dhcpd6</screen>
+   </step>
+  </procedure>
+ </section>
+
+ <section xml:id="configure-tftp-server">
+  <title>Configuring the TFTP server (optional)</title>
+  <para>
+   You must configure a TFTP server if you want to use both PXE Boot and HTTP Boot.
+  </para>
+  <procedure>
+   <step>
+    <para>
+     Install the <package>tftp</package> package:
+    </para>
+<screen>&prompt.root;zypper install tftp</screen>
+   </step>
+   <step>
+    <para>
+     Enable and start the TFTP service:
+    </para>
+<screen>&prompt.root;systemctl enable --now tftp.socket
+&prompt.root;systemctl enable --now tftp.service</screen>
+   </step>
+   <step>
+    <para>
+     List the available <package>tftpboot-installation</package> packages:
+    </para>
+<screen>&prompt.root;zypper se tftpboot</screen>
+   </step>
+   <step>
+    <para>
+     Install the appropriate package for your version and architecture.
+     For example:
+    </para>
+<screen>&prompt.root;zypper install tftpboot-installation-SLE-15-SP3-x86_64</screen>
+   </step>
+   <step>
+    <para>
+     Copy the content of the
+     <filename>SLE-<replaceable>VERSION</replaceable>-<replaceable>ARCH</replaceable></filename>
+     directory to the root directory of the TFTP server. For example:
+    </para>
+<screen>&prompt.root;cp -r /usr/share/tftpboot-installation/SLE-15-SP3-x86_64 /srv/tftpboot</screen>
+   </step>
+  </procedure>
+  <para>
+   For more information, see
+   <filename>/usr/share/tftpboot-installation/SLE-<replaceable>VERSION</replaceable>-<replaceable>ARCH</replaceable>/README</filename>.
+  </para>
+ </section>
+
+ <section xml:id="httpboot-http-server">
+  <title>Configuring the HTTP server</title>
+  <procedure>
+   <step>
+    <para>
+     Install the <package>apache2</package> package:
+    </para>
+<screen>&prompt.root;zypper install apache2</screen>
+   </step>
+   <step>
+    <para>
+     In the HTTP boot server directory (<literal>/srv/www/htdocs/</literal>),
+     create a subdirectory for the installation content. For example,
+     <literal>/srv/www/htdocs/sle/</literal>:
+    </para>
+<screen>&prompt.user;cd /srv/www/htdocs
+&prompt.user;mkdir sle</screen>
+   </step>
+   <step>
+    <para>
+     Copy all of the contents of the ISO image to the
+     <literal>/srv/www/htdocs/sle/</literal> directory.
+    </para>
+   </step>
+   <step>
+    <para>
+     To configure the boot menu, edit the
+     <filename>/srv/www/htdocs/sle/EFI/BOOT/grub.cfg</filename> file. Use the
+     following example as a reference:
+    </para>
+<screen> menuentry 'Installation IPv4' --class opensuse --class gnu-linux --class gnu --class os {
+  set gfxpayload=keep
+  echo 'Loading kernel ...'
+  linuxefi /sle/boot/x86_64/loader/linux install=http://www.httpboot.local/sle
+  echo 'Loading initial ramdisk ...'
+  initrdefi /sle/boot/x86_64/loader/initrd
+ }
+
+ menuentry 'Installation IPv6' --class opensuse --class gnu-linux --class gnu --class os {
+  set gfxpayload=keep
+  echo 'Loading kernel ...'
+  linuxefi /sle/boot/x86_64/loader/linux install=http://www.httpboot.local/sle ipv6only=1 ifcfg=*=dhcp6,DHCLIENT6_MODE=managed
+  echo 'Loading initial ramdisk ...'
+  initrdefi /sle/boot/x86_64/loader/initrd
+ }</screen>
+   </step>
+   <step>
+    <para>
+     Enable and start <literal>apache2</literal>:
+    </para>
+<screen>&prompt.root;systemctl enable --now apache2</screen>
+   </step>
+  </procedure>
+ </section>
+
+ <section xml:id="httpboot-http-server-ssl-support">
+  <title>Enabling SSL support for the HTTP server (optional)</title>
+  <para>
+   HTTPS Boot is only supported on &sle; 15 and newer. To use HTTPS Boot, you must convert an existing server certificate
+   into the <literal>DER</literal> format and enroll it into the client's
+   firmware.
+  </para>
+  <procedure>
+   <step>
+    <para>
+     Assuming you already have a certificate installed on your server, convert
+     it into the <literal>DER</literal> format for use with the client:
+    </para>
+<screen>&prompt.root;openssl x509 -in <replaceable>CERTIFICATE</replaceable>.crt \
+-outform der -out <replaceable>CERTIFICATE</replaceable>.der</screen>
+   </step>
+   <step>
+    <para>
+     Enroll the server certificate into the client firmware.
+    </para>
+    <para>
+     The exact procedure for enrolling the converted certificate depends on the
+     specific implementation of the client's firmware. For certain hardware,
+     you must enroll the certificate manually via the firmware UI using an
+     external storage device with the certificate on it. Machines with Redfish
+     support can enroll the certificate remotely. Consult the documentation for
+     your specific hardware for more information on enrolling certificates.
+    </para>
+   </step>
+   <step>
+    <para>
+     Add the SSL flag to the <filename>/etc/sysconfig/apache2</filename> file:
+    </para>
+<screen>APACHE_SERVER_FLAGS="SSL"</screen>
+   </step>
+   <step>
+    <para>
+     In the same file, ensure that the <literal>ssl</literal> module is listed in
+     <literal>APACHE_MODULES</literal>. For example:
+    </para>
+<screen>APACHE_MODULES="actions alias auth_basic authn_file authz_host authz_groupfile authz_core
+authz_user autoindex cgi dir env expires include log_config mime negotiation setenvif <emphasis role="bold">ssl</emphasis>
+socache_shmcb userdir reqtimeout authn_core headers proxy proxy_http proxy_wstunnel"</screen>
+   </step>
+   <step>
+    <para>
+     Copy the private key and the certificate to the
+     <filename>/etc/apache2/</filename> directory:
+    </para>
+<screen>&prompt.root;cp server.key /etc/apache2/ssl.key/
+&prompt.root;chown wwwrun /etc/apache2/ssl.key/server.key
+&prompt.root;chmod 600 /etc/apache2/ssl.key/server.key
+&prompt.root;cp server.crt /etc/apache2/ssl.crt/</screen>
+   </step>
+   <step>
+    <para>
+     Create the SSL vhost configuration:
+    </para>
+<screen>&prompt.root;cd /etc/apache2/vhosts.d
+&prompt.root;cp vhost-ssl.template vhost-ssl.conf</screen>
+   </step>
+   <step>
+    <para>
+     Change the private key and the certificate in the
+     <filename>/etc/apache2/vhosts.d/vhost-ssl.conf</filename>
+     file to the following values:
+    </para>
+<screen>SSLCertificateFile /etc/apache2/ssl.crt/server.crt
+SSLCertificateKeyFile /etc/apache2/ssl.key/server.key</screen>
+   </step>
+   <step>
+    <para>
+     Restart Apache to activate the SSL support:
+    </para>
+<screen>&prompt.root;systemctl restart apache2</screen>
+   </step>
+   <step>
+    <para>
+     Replace the <literal>http://</literal> prefix with
+     <literal>https://</literal> in <filename>dhcpd.conf</filename>
+     and <filename>dhcpd6.conf</filename>.
+    </para>
+   </step>
+   <step>
+    <para>
+     Restart the DHCP server:
+    </para>
+<screen>&prompt.root;systemctl restart dhcpd
+&prompt.root;systemctl restart dhcpd6</screen>
+   </step>
+  </procedure>
+ </section>
+
+ <section xml:id="summary-set-up-uefi-http-boot-server">
+  <title>Summary</title>
+  <para><!-- TODO Expand and improve -->
+   Enabling HTTP Boot on a physical client machine depends on your specific
+   hardware. Consult the documentation for further information on how to
+   enable HTTP Boot on your particular machine.
+  </para>
+  <para>
+   If the firmware already supports HTTP boot, plug in the cable and choose the
+   correct boot option.
+  </para>
+ </section>
+
+ <section xml:id="troubleshooting-set-up-uefi-http-boot-server">
+  <title>Troubleshooting</title>
+  <variablelist>
+   <varlistentry>
+    <term>Problem phrased as question</term>
+    <listitem>
+     <para>
+      If DHCPv6 packets are dropped by the RP filter in the firewall, check its
+      log. In case it contains the <literal>rpfilter_DROP</literal> entry,
+      disable the filter using the following configuration in
+      <filename>/etc/firewalld/firewalld.conf</filename>:
+     </para>
+     <screen>IPv6_rpfilter=no</screen>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>Another problem phrased as question</term>
+    <listitem>
+     <para>
+      Another paragraph of text.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </section>
+
+ <section xml:id="next-set-up-uefi-http-boot-server">
+  <title>Next steps</title>
+  <itemizedlist>
+   <listitem>
+    <para>
+     An
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Unordered
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     List
+    </para>
+   </listitem>
+  </itemizedlist>
+ </section>
+
+ <section xml:id="related-set-up-uefi-http-boot-server">
+  <title>Related topics</title>
+  <itemizedlist>
+   <listitem>
+    <para>
+     Setting up a PXE boot server
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Unordered
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     List
+    </para>
+   </listitem>
+  </itemizedlist>
+ </section>
+</article>

--- a/xml/task-set-up-uefi-http-boot-server.xml
+++ b/xml/task-set-up-uefi-http-boot-server.xml
@@ -110,12 +110,12 @@ https://documentation.suse.com/sles/15-SP3/html/SLES-all/cha-deployment-prep-uef
      Add the following lines to the <filename>/etc/dnsmasq.conf</filename> file:
     </para>
 <screen>interface=eth0
-addn-hosts=/etc/dnsmasq.d/hosts.conf</screen>
+addn-hosts=/etc/hosts.conf</screen>
    </step>
    <step>
     <para>
      Assign a domain name to the IP addresses in the
-     <filename>/etc/dnsmasq.d/hosts.conf</filename> file:
+     <filename>/etc/hosts.conf</filename> file:
     </para>
 <screen>192.168.111.1 www.httpboot.local
 2001:db8:f00f:cafe::1 www.httpboot.local</screen>

--- a/xml/task-set-up-uefi-http-boot-server.xml
+++ b/xml/task-set-up-uefi-http-boot-server.xml
@@ -80,8 +80,7 @@ https://documentation.suse.com/sles/15-SP3/html/SLES-all/cha-deployment-prep-uef
    </listitem>
    <listitem>
     <para>
-     You have a &sles; ISO image available, either on a media drive or downloaded
-     on your server.
+     You have a &sles; ISO image available.
     </para>
    </listitem>
    <listitem>
@@ -104,7 +103,7 @@ https://documentation.suse.com/sles/15-SP3/html/SLES-all/cha-deployment-prep-uef
     <para>
      Install the <package>dnsmasq</package> package:
     </para>
-<screen>&prompt.user;sudo zypper install dnsmasq</screen>
+<screen>&prompt.user;<command>sudo zypper install dnsmasq</command></screen>
    </step>
    <step>
     <para>
@@ -125,7 +124,7 @@ addn-hosts=/etc/dnsmasq.d/hosts.conf</screen>
     <para>
      Enable and start the DNS server:
     </para>
- <screen>&prompt.user;sudo systemctl enable --now dnsmasq</screen>
+ <screen>&prompt.user;<command>sudo systemctl enable --now dnsmasq</command></screen>
    </step>
   </procedure>
   <note>
@@ -145,7 +144,7 @@ addn-hosts=/etc/dnsmasq.d/hosts.conf</screen>
     <para>
      Install the <package>apache2</package> package:
     </para>
-<screen>&prompt.user;sudo zypper install apache2</screen>
+<screen>&prompt.user;<command>sudo zypper install apache2</command></screen>
    </step>
    <step>
     <para>
@@ -153,7 +152,7 @@ addn-hosts=/etc/dnsmasq.d/hosts.conf</screen>
      create a subdirectory for the installation content. For example,
      <literal>/srv/www/htdocs/sle/</literal>:
     </para>
-<screen>&prompt.user;sudo mkdir /srv/www/htdocs/sle</screen>
+<screen>&prompt.user;<command>sudo mkdir /srv/www/htdocs/sle</command></screen>
    </step>
    <step>
     <para>
@@ -186,7 +185,7 @@ addn-hosts=/etc/dnsmasq.d/hosts.conf</screen>
     <para>
      Enable and start <literal>apache2</literal>:
     </para>
-<screen>&prompt.user;sudo systemctl enable --now apache2</screen>
+<screen>&prompt.user;<command>sudo systemctl enable --now apache2</command></screen>
    </step>
   </procedure>
  </section>
@@ -202,7 +201,7 @@ addn-hosts=/etc/dnsmasq.d/hosts.conf</screen>
     <para>
      Install the <package>dhcp-server</package> package:
     </para>
-<screen>&prompt.user;sudo zypper install dhcp-server</screen>
+<screen>&prompt.user;<command>sudo zypper install dhcp-server</command></screen>
    </step>
    <step>
     <para>
@@ -279,8 +278,8 @@ subnet6 2001:db8:f00f:cafe::/64 {
     <para>
      Start the DHCP servers:
     </para>
-<screen>&prompt.user;sudo systemctl enable --now dhcpd
-&prompt.user;sudo systemctl enable --now dhcpd6</screen>
+<screen>&prompt.user;<command>sudo systemctl enable --now dhcpd</command>
+&prompt.user;<command>sudo systemctl enable --now dhcpd6</command></screen>
    </step>
   </procedure>
  </section>
@@ -301,7 +300,7 @@ subnet6 2001:db8:f00f:cafe::/64 {
     <para>
      Convert the certificate into the <literal>DER</literal> format:
     </para>
-<screen>&prompt.user;sudo openssl x509 -in <replaceable>CERTIFICATE</replaceable>.crt -outform der -out <replaceable>CERTIFICATE</replaceable>.der</screen>
+<screen>&prompt.user;<command>sudo openssl x509 -in <replaceable>CERTIFICATE</replaceable>.crt -outform der -out <replaceable>CERTIFICATE</replaceable>.der</command></screen>
    </step>
    <step>
     <para>
@@ -325,7 +324,7 @@ subnet6 2001:db8:f00f:cafe::/64 {
      In the same file, ensure that the <literal>ssl</literal> module appears in
      the <literal>APACHE_MODULES</literal> list:
     </para>
-<screen>&prompt.user;sudo <command>grep 'APACHE_MODULES.*ssl' /etc/sysconfig/apache2</command>
+<screen>&prompt.user;<command>sudo grep 'APACHE_MODULES.*ssl' /etc/sysconfig/apache2</command>
 <emphasis role="bold">APACHE_MODULES</emphasis>="actions alias auth_basic authn_core authn_file authz_host
 authz_groupfile authz_core authz_user autoindex cgi dir env expires include
 log_config mime negotiation setenvif <emphasis role="bold">ssl</emphasis> socache_shmcb userdir reqtimeout"</screen>
@@ -335,16 +334,16 @@ log_config mime negotiation setenvif <emphasis role="bold">ssl</emphasis> socach
      Copy the private key and the certificate to the
      <filename>/etc/apache2/</filename> directory:
     </para>
-<screen>&prompt.user;sudo cp server.key /etc/apache2/ssl.key/
-&prompt.user;sudo chown wwwrun /etc/apache2/ssl.key/server.key
-&prompt.user;sudo chmod 600 /etc/apache2/ssl.key/server.key
-&prompt.user;sudo cp server.crt /etc/apache2/ssl.crt/</screen>
+<screen>&prompt.user;<command>sudo cp server.key /etc/apache2/ssl.key/</command>
+&prompt.user;<command>sudo chown wwwrun /etc/apache2/ssl.key/server.key</command>
+&prompt.user;<command>sudo chmod 600 /etc/apache2/ssl.key/server.key</command>
+&prompt.user;<command>sudo cp server.crt /etc/apache2/ssl.crt/</command></screen>
    </step>
    <step>
     <para>
      Create the SSL vhost configuration:
     </para>
-<screen>&prompt.user;sudo cp /etc/apache2/vhosts.d/vhost-ssl.template /etc/apache2/vhosts.d/vhost-ssl.conf</screen>
+<screen>&prompt.user;<command>sudo cp /etc/apache2/vhosts.d/vhost-ssl.template /etc/apache2/vhosts.d/vhost-ssl.conf</command></screen>
    </step>
    <step>
     <para>
@@ -358,7 +357,7 @@ SSLCertificateKeyFile /etc/apache2/ssl.key/server.key</screen>
     <para>
      Restart Apache to activate the SSL support:
     </para>
-<screen>&prompt.user;sudo systemctl restart apache2</screen>
+<screen>&prompt.user;<command>sudo systemctl restart apache2</command></screen>
    </step>
    <step>
     <para>
@@ -373,8 +372,8 @@ SSLCertificateKeyFile /etc/apache2/ssl.key/server.key</screen>
     <para>
      Restart the DHCP servers:
     </para>
-<screen>&prompt.user;sudo systemctl restart dhcpd
-&prompt.user;sudo systemctl restart dhcpd6</screen>
+<screen>&prompt.user;<command>sudo systemctl restart dhcpd</command>
+&prompt.user;<command>sudo systemctl restart dhcpd6</command></screen>
    </step>
   </procedure>
  </section>
@@ -382,9 +381,9 @@ SSLCertificateKeyFile /etc/apache2/ssl.key/server.key</screen>
  <section xml:id="summary-set-up-uefi-http-boot-server">
   <title>Summary</title>
   <para>
-   You can now use this server to remotely install operating systems from an
-   HTTP URL, if the client firmware supports HTTP Boot. Consult the relevant
-   documentation for information on how to enable HTTP Boot on client machines.
+   You can now use this server to remotely install operating systems on clients
+   that support HTTP Boot. Consult the relevant documentation for information
+   on how to enable HTTP Boot on client machines.
   </para>
  </section>
 
@@ -395,8 +394,8 @@ SSLCertificateKeyFile /etc/apache2/ssl.key/server.key</screen>
     <term>RP filter dropping DHCPv6 packets</term>
     <listitem>
      <para>
-      If DHCPv6 packets are dropped by the RP filter in the firewall, check its
-      log. In case it contains the <literal>rpfilter_DROP</literal> entry,
+      If DHCPv6 packets are dropped by the RP filter in the firewall, check the
+      firewall log. If it contains the <literal>rpfilter_DROP</literal> entry,
       disable the filter using the following configuration in
       <filename>/etc/firewalld/firewalld.conf</filename>:
      </para>

--- a/xml/task-set-up-uefi-http-boot-server.xml
+++ b/xml/task-set-up-uefi-http-boot-server.xml
@@ -43,7 +43,7 @@ https://documentation.suse.com/sles/15-SP3/html/SLES-all/cha-deployment-prep-uef
 
 <section xml:id="environment-set-up-uefi-http-boot-server">
  <title>Environment</title>
-  <para>This document applies to the following products and product versions:</para>
+  <para>This document applies to the following product and product versions:</para>
   <itemizedlist>
   <listitem>
    <para>&sles;&nbsp;15&nbsp;SP3, 15&nbsp;SP2, 15&nbsp;SP1, 15&nbsp;GA, 12&nbsp;SP5, 12&nbsp;SP4, 12&nbsp;SP3</para>


### PR DESCRIPTION
Rendered PDF:
[task-set-up-uefi-http-boot-server_color_en.pdf](https://github.com/SUSE/doc-modular/files/7174122/task-set-up-uefi-http-boot-server_color_en.pdf)
