### PR TITLE
ALP: Fix YAML examples for Ignition + Miscellaneous improvements

### DIFF
--- a/xml/concept-configure-ignition.xml
+++ b/xml/concept-configure-ignition.xml
@@ -31,7 +31,8 @@
  <section xml:id="what-is-ignition">
   <title>What is &ignition;?</title>
   <para>
-   &ignition; is a provisioning tool that enables you to configure a system
+   <link xlink:href="https://coreos.github.io/ignition/">&ignition;</link>
+   is a provisioning tool that enables you to configure a system
    according to your specification on the first boot.
   </para>
  </section>

--- a/xml/reference-ignition-configuration.xml
+++ b/xml/reference-ignition-configuration.xml
@@ -69,7 +69,7 @@ variant: fcos
 version: 1.0.0
 storage:
   disks:
-    - device:	"/dev/vda"
+    - device: "/dev/vda"
       wipeTable: true
       partitions:
        - label: root
@@ -78,7 +78,7 @@ storage:
        - label: boot
          number: 2
          typeGuid: BC13C2FF-59E6-4262-A352-B275FD6F7172
-        - label: swap
+       - label: swap
          number: 3
          typeGuid: 0657FD6D-A4AB-43C4-84E5-0933C84B4F4F
        - label: home

--- a/xml/reference-ignition-configuration.xml
+++ b/xml/reference-ignition-configuration.xml
@@ -70,20 +70,20 @@ version: 1.0.0
 storage:
   disks:
     - device: "/dev/vda"
-      wipeTable: true
+      wipe_table: true
       partitions:
        - label: root
          number: 1
-         typeGuid: 4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709
+         type_guid: 4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709
        - label: boot
          number: 2
-         typeGuid: BC13C2FF-59E6-4262-A352-B275FD6F7172
+         type_guid: BC13C2FF-59E6-4262-A352-B275FD6F7172
        - label: swap
          number: 3
-         typeGuid: 0657FD6D-A4AB-43C4-84E5-0933C84B4F4F
+         type_guid: 0657FD6D-A4AB-43C4-84E5-0933C84B4F4F
        - label: home
          number: 4
-         typeGuid: 933AC7E1-2EB4-4F13-B844-0E14E2AEF915
+         type_guid: 933AC7E1-2EB4-4F13-B844-0E14E2AEF915
  </screen>
    </section>
    <section xml:id="sec-storage-raid">
@@ -123,10 +123,12 @@ storage:
 variant: fcos
 version: 1.0.0
 storage:
-	- raid: data
-	  name: system
-	  level: raid1
-	  devices: "/dev/sda", "/dev/sdb"
+  raid:
+    - name: system
+      level: raid1
+      devices:
+        - "/dev/sda"
+        - "/dev/sdb"
  </screen>
    </section>
    <section xml:id="sec-storage-filesystem">
@@ -214,9 +216,9 @@ variant: fcos
 version: 1.0.0
 storage:
   directories:
-  	- path: /home/tux/
-  	  user:
-  	   - name: tux
+    - path: /home/tux
+      user:
+        name: tux
  </screen>
    </section>
   </section>

--- a/xml/reference-ignition-configuration.xml
+++ b/xml/reference-ignition-configuration.xml
@@ -49,7 +49,7 @@
    <para>
     The <literal>storage</literal> attribute is used to configure partitions,
     RAID, define file systems, create files, etc. To define partitions, use the
-    <literal>disks</literal> attribute. The <literal>filesystem</literal>
+    <literal>disks</literal> attribute. The <literal>filesystems</literal>
     attribute is used to format partitions and define mount points of
     particular partitions. The <literal>files</literal> attribute can be used
     to create files in the file system. Each of the mentioned attributes is
@@ -130,9 +130,9 @@ storage:
  </screen>
    </section>
    <section xml:id="sec-storage-filesystem">
-    <title>The <literal>filesystem</literal> attribute</title>
+    <title>The <literal>filesystems</literal> attribute</title>
     <para>
-     <literal>filesystem</literal> must contain the following attributes:
+     <literal>filesystems</literal> must contain the following attributes:
     </para>
     <variablelist>
      <varlistentry>
@@ -160,7 +160,7 @@ storage:
      </varlistentry>
     </variablelist>
     <para>
-     The following example demonstrates using the <literal>filesystem</literal>
+     The following example demonstrates using the <literal>filesystems</literal>
      attribute. The <filename>/opt</filename> directory will be mounted to the
      <literal>/dev/sda1</literal> partition, which is formatted to btrfs. The
      partition table will not be erased.
@@ -182,7 +182,7 @@ storage:
      You can use the <literal>files</literal> attribute to create any files on
      your machine. Bear in mind that if you want to create files outside the
      default partitioning schema, you need to define the directories by using
-     the <literal>filesystem</literal> attribute.
+     the <literal>filesystems</literal> attribute.
     </para>
     <para>
      In the following example, a host name is created by using the

--- a/xml/reference-ignition-configuration.xml
+++ b/xml/reference-ignition-configuration.xml
@@ -163,7 +163,7 @@ storage:
      The following example demonstrates using the <literal>filesystems</literal>
      attribute. The <filename>/opt</filename> directory will be mounted to the
      <literal>/dev/sda1</literal> partition, which is formatted to btrfs. The
-     partition table will not be erased.
+     device will not be erased.
     </para>
 <screen>
 variant: fcos

--- a/xml/task-convert-yaml-to-json.xml
+++ b/xml/task-convert-yaml-to-json.xml
@@ -48,19 +48,14 @@
   </para>
 <screen>
 &prompt.sudo; zypper ar -f \
-  https://download.opensuse.org/repositories/devel:/kubic:/ignition/<replaceable>DISTRIBUTION</replaceable>/ \
+  https://download.opensuse.org/repositories/devel:/kubic:/ignition/openSUSE_Tumbleweed/ \
   devel_kubic_ignition
 </screen>
   <para>
-   Replace <replaceable>DISTRIBUTION</replaceable> with one of the following
+   Replace <literal>openSUSE_Tumbleweed</literal> with one of the following
    (depending on your distribution):
   </para>
   <itemizedlist>
-   <listitem>
-    <para>
-     <literal>openSUSE_Tumbleweed</literal>
-    </para>
-   </listitem>
    <listitem>
     <para>
      <literal>'openSUSE_Leap_$releasever'</literal>

--- a/xml/task-convert-yaml-to-json.xml
+++ b/xml/task-convert-yaml-to-json.xml
@@ -63,7 +63,7 @@
    </listitem>
    <listitem>
     <para>
-     <literal>openSUSE_Leap_$release_number</literal>
+     <literal>'openSUSE_Leap_$releasever'</literal>
     </para>
    </listitem>
    <listitem>

--- a/xml/task-deploy-alp.xml
+++ b/xml/task-deploy-alp.xml
@@ -136,7 +136,7 @@
    <step>
     <para>
      Download &alpshort; virtual machine image on the host where you will run
-     &alpshort;. Go to &alp-dld-site;, and download the latest disk image of
+     &alpshort;. Go to <link xlink:href="&alp-dld-site;"/>, and download the latest disk image of
      &alpshort;. For example:
     </para>
 <screen>&prompt.user;curl -LO &alp-dld-site;ALP-VM.x86_64-0.0.1-kvm-Build9.1.qcow2</screen>


### PR DESCRIPTION
I started with minor things but then found several examples of YAML snippets for Ignition which were unusable so that will be the focus of this PR.

For reference, the rendered docs for `main` branch is at https://susedoc.github.io/doc-modular/main/html/alp/index.html