### PR TITLE
Mention pattern install in transactional-update

### DIFF
--- a/xml/reference-transactional-update-usage.xml
+++ b/xml/reference-transactional-update-usage.xml
@@ -319,6 +319,10 @@ transactional-update <option>[option]</option> <replaceable>[general_command]</r
             or
           </para>
 <screen>&prompt.root;<command>transactional-update pkg install <replaceable>rpm1 rpm2</replaceable></command></screen>
+          <para>
+            or to install a pattern
+          </para>
+<screen>&prompt.root;<command>transactional-update pkg install -t pattern <replaceable>pattern_name</replaceable></command></screen>
         </listitem>
       </varlistentry>
       <varlistentry>

--- a/xml/reference-transactional-update-usage.xml
+++ b/xml/reference-transactional-update-usage.xml
@@ -320,7 +320,7 @@ transactional-update <option>[option]</option> <replaceable>[general_command]</r
           </para>
 <screen>&prompt.root;<command>transactional-update pkg install <replaceable>rpm1 rpm2</replaceable></command></screen>
           <para>
-            or to install a pattern
+            Or, to install a software pattern:
           </para>
 <screen>&prompt.root;<command>transactional-update pkg install -t pattern <replaceable>pattern_name</replaceable></command></screen>
         </listitem>


### PR DESCRIPTION
### Description

Improvement to ALP `transactional-update` usage cases, since there is no mention about installing patterns.