### PR TITLE
Fix entity for article 'Registering and deregistering your product after installation'

### DIFF
--- a/DC-task-register-deregister-product-after-installation
+++ b/DC-task-register-deregister-product-after-installation
@@ -7,6 +7,7 @@ ROOTID="task-register-product-after-installation"
 PROFCONDITION="suse-product"
 #PROFCONDITION="suse-product;beta"
 #PROFCONDITION="community-project"
+PROFOS="sles"
 
 DRAFT=1
 

--- a/common/product-entities.ent
+++ b/common/product-entities.ent
@@ -2,7 +2,7 @@
 <!-- This file can be edited downstream. -->
 
 <!-- PRODUCT NAME AND VERSIONS -->
-<!ENTITY productname            "<phrase xmlns='http://docbook.org/ns/docbook'><phrase os='alp-micro'>&suse; ALP Micro</phrase><phrase os='alp-bedrock'>&suse; ALP Bedrock</phrase><phrase os='slemicro'>&slem;</phrase></phrase>">
+<!ENTITY productname            "<phrase xmlns='http://docbook.org/ns/docbook'><phrase os='alp-micro'>&suse; ALP Micro</phrase><phrase os='alp-bedrock'>&suse; ALP Bedrock</phrase><phrase os='slemicro'>&slem;</phrase><phrase os='sles'>&sles;</phrase></phrase>">
 <!ENTITY productnameshort       "<phrase xmlns='http://docbook.org/ns/docbook'><phrase os='alp-micro'>ALP Micro</phrase><phrase os='alp-bedrock'>ALP Bedrock</phrase><phrase os='slemicro'>&slema;</phrase></phrase>">
 <!ENTITY productnumber          "<phrase xmlns='http://docbook.org/ns/docbook'><phrase os='slemicro'>5.4</phrase></phrase>">
 


### PR DESCRIPTION
### Description

An entity value and profiling for SLES was missing, therefore with the latest updates to &productname; in common/product-entities.ent the entity was replaced by 'SUSE ALP MicroSUSE ALP BedrockSUSE Linux Enterprise Micro' in the output on documentation.suse.com


