### PR TITLE
Add missing xml:lang in structure

### DIFF
--- a/templates/articles/assembly.asm.xml
+++ b/templates/articles/assembly.asm.xml
@@ -58,7 +58,7 @@
     </resource>
   </resources>
   <!-- S T R U C T U R E -->
-  <structure renderas="article" xml:id="article-example">
+  <structure renderas="article" xml:id="article-example" xml:lang="en">
     <merge>
       <title>Your title, limit to 55 characters, if possible</title>
       <subtitle>Subtitle if necessary</subtitle>


### PR DESCRIPTION
### Description

Our `<structure>` start tag doesn't have a language set. This PR sets the `xml:lang` attribute so it's ready for translation.

This was the answer that I got from the DocBook mailinglist.


### Are there any relevant issues/feature requests?

* [post to docbook mailinglist on 2023-04-19](https://lists.oasis-open.org/archives/docbook/202304/msg00012.html)