### PR TITLE
Replace &prompt; -> &prompt.sudo;

### DIFF
--- a/tasks/systemd-mailto.xml
+++ b/tasks/systemd-mailto.xml
@@ -70,7 +70,7 @@ Group=systemd-journal
       <para>
         Verify the service file, and fix the reported issues:
       </para>
-<screen>&prompt;systemd-analyze verify /etc/systemd/system/send_email_to_<replaceable>USER</replaceable>@.service</screen>
+<screen>&prompt.sudo;systemd-analyze verify /etc/systemd/system/send_email_to_<replaceable>USER</replaceable>@.service</screen>
       <para>
         If the command returns no output, the file has passed the verification successfully.
       </para>

--- a/tasks/systemd-timer-create.xml
+++ b/tasks/systemd-timer-create.xml
@@ -64,7 +64,7 @@ WantedBy=multi-user.target
         <para>
           Verify that the files you created above contain no errors:
         </para>
-<screen>&prompt;systemd-analyze verify /etc/systemd/system/helloworld.*</screen>
+<screen>&prompt.sudo;systemd-analyze verify /etc/systemd/system/helloworld.*</screen>
         <para>
           If the command returns no output, the files have passed the verification successfully.
         </para>

--- a/tasks/systemd-timer-test-cal-entries.xml
+++ b/tasks/systemd-timer-test-cal-entries.xml
@@ -27,13 +27,13 @@
     show the string in <literal>Normalized form</literal>, and it is recommended to use that string
     in the timer file. Consider the following examples:
   </para>
-<screen>&prompt;systemd-analyze calendar "Tue,Sun *-*-* 01,03:00:00"
+<screen>&prompt.sudo;systemd-analyze calendar "Tue,Sun *-*-* 01,03:00:00"
 Normalized form: Tue,Sun *-*-* 01,03:00:00
 Next elapse: Sun 2021-10-31 01:00:00 CEST
 (in UTC): Sat 2021-10-30 23:00:00 UTC
 From now: 3 days left
 
-&prompt;systemd-analyze calendar "Mon..Fri *-*-* 10:00" "Sat,Sun *-*-* 22:00"
+&prompt.sudo;systemd-analyze calendar "Mon..Fri *-*-* 10:00" "Sat,Sun *-*-* 22:00"
 Original form: Mon..Fri *-*-* 10:00
 Normalized form: Mon..Fri *-*-* 10:00:00
 Next elapse: Thu 2021-10-28 10:00:00 CEST
@@ -51,7 +51,7 @@ From now: 3 days left</screen>
     <replaceable>N</replaceable> specifies the number of iterations you would like to test. The
     following example string triggers every 8 hours (starting at 00:00:00) on Sundays:
   </para>
-<screen>&prompt;systemd-analyze calendar --iterations 5 "Sun *-*-* 0/08:00:00"
+<screen>&prompt.sudo;systemd-analyze calendar --iterations 5 "Sun *-*-* 0/08:00:00"
 Original form: Sun *-*-* 0/08:00:00
 Normalized form: Sun *-*-* 00/8:00:00
 Next elapse: Sun 2021-10-31 00:00:00 CEST


### PR DESCRIPTION
### Description

After I've tried to test a document, I've stumbled upon some XML errors. It turned out some lines contain `&prompt;`. However, that entity doesn't exist. I replaced it with `&prompt.sudo;`.


### Are there any relevant issues/feature requests?

n/a