### PR TITLE
Add abstracts to info section for topics

### DIFF
--- a/templates/concepts/concept.xml
+++ b/templates/concepts/concept.xml
@@ -16,9 +16,14 @@
  xmlns:xlink="http://www.w3.org/1999/xlink"
  xmlns:trans="http://docbook.org/ns/transclusion">
   <info>
-    <title>Concept</title>
+    <title>Concept</title><!-- can be changed via merge in the assembly -->
     <!--add author's email address-->
     <meta name="maintainer" content="" its:translate="no"/>
+    <abstract><!-- can be changed via merge in the assembly -->
+      <para>
+       Introductory text
+      </para>
+    </abstract>
   </info>
   <section xml:id="concept-example-what-is">
     <title>What is foo bar?</title>

--- a/templates/glues/glue-more-info.xml
+++ b/templates/glues/glue-more-info.xml
@@ -12,9 +12,12 @@
  xmlns:xlink="http://www.w3.org/1999/xlink"
  xmlns:trans="http://docbook.org/ns/transclusion">
   <info>
-    <title>For more information</title>
+    <title>For more information</title><!-- can be changed via merge in the
+assembly -->
     <!--add author's e-mail address-->
     <meta name="maintainer" content="" its:translate="no"/>
+    <!-- add an abstract/para here, if you need one -->
+    <!-- can be changed via merge in the assembly -->
   </info>
   <para>
     Add web links to external sources or other SUSE articles.

--- a/templates/glues/glue-whats-next.xml
+++ b/templates/glues/glue-whats-next.xml
@@ -11,10 +11,12 @@
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink"
  xmlns:trans="http://docbook.org/ns/transclusion">
-  <title>What's next?</title>
+  <title>What's next?</title><!-- can be changed via merge in the assembly -->
   <info>
-    <!--add author's email address-->
+    <!--add author's email address -->
     <meta name="maintainer" content="" its:translate="no"/>
+    <!-- add an abstract/para here, if you need one -->
+    <!-- can be changed via merge in the assembly -->
   </info>
   <para>
     Add list of web links to articles relating to this topic that the user

--- a/templates/glues/glue.xml
+++ b/templates/glues/glue.xml
@@ -16,9 +16,12 @@
  xmlns:xlink="http://www.w3.org/1999/xlink"
  xmlns:trans="http://docbook.org/ns/transclusion">
   <info>
-  <title>Performing Task XYZ</title>
-    <!--add author's email address-->
+    <title>Performing Task XYZ</title><!-- can be changed via merge in the
+    assembly -->
+    <!-- add author's email address -->
     <meta name="maintainer" content="" its:translate="no"/>
+    <!-- add an abstract/para here, if you need one -->
+    <!-- can be changed via merge in the assembly -->
   </info>
   <!-- This is an example of how a glue topic would look like. If your task contains a large number of independent subtasks, make sure to include the glue topic to provide a means of navigation and to tie them together -->
   <para>

--- a/templates/references/reference.xml
+++ b/templates/references/reference.xml
@@ -16,9 +16,14 @@
  xmlns:xlink="http://www.w3.org/1999/xlink"
  xmlns:trans="http://docbook.org/ns/transclusion">
   <info>
-    <title>Reference</title>
+   <title>Reference</title><!-- ccan be changed via merge in the assembly -->
     <!--add author's email address-->
     <meta name="maintainer" content="" its:translate="no"/>
+    <abstract><!-- can be changed via merge in the assembly -->
+      <para>
+       Introductory text
+      </para>
+    </abstract>
   </info>
   <section xml:id="reference-example-section">
     <title>Section title</title>

--- a/templates/references/reference.xml
+++ b/templates/references/reference.xml
@@ -16,7 +16,7 @@
  xmlns:xlink="http://www.w3.org/1999/xlink"
  xmlns:trans="http://docbook.org/ns/transclusion">
   <info>
-   <title>Reference</title><!-- ccan be changed via merge in the assembly -->
+   <title>Reference</title><!-- can be changed via merge in the assembly -->
     <!--add author's email address-->
     <meta name="maintainer" content="" its:translate="no"/>
     <abstract><!-- can be changed via merge in the assembly -->

--- a/templates/tasks/task.xml
+++ b/templates/tasks/task.xml
@@ -16,9 +16,15 @@
  xmlns:xlink="http://www.w3.org/1999/xlink"
  xmlns:trans="http://docbook.org/ns/transclusion">
   <info>
-    <title>Executing task X (with tool Y)</title>
+    <title>Executing task X (with tool Y)</title><!-- can be changed via merge
+in the assembly -->
     <!-- add author's e-mail -->
     <meta name="maintainer" content="" its:translate="no"/>
+    <abstract><!-- can be changed via merge in the assembly -->
+      <para>
+       Introductory text
+      </para>
+    </abstract>
   </info>
   <section xml:id="task-example-introduction">
     <title>Introduction</title>


### PR DESCRIPTION
As discussed on SLE writers call. Have title and abstract inside info in order to allow for merge to do it's magic.