### PR TITLE
Remove pointless sed call after uname -p

### DIFF
--- a/xml/concept-bci-get-started.xml
+++ b/xml/concept-bci-get-started.xml
@@ -432,7 +432,7 @@
       </listitem>
       <listitem>
        <para>
-        &bcia;: <command>arch="$(uname -p|sed 's/x86_64/amd64/')"</command>
+        &bcia;: <command>arch="$(uname -p)"</command>
        </para>
       </listitem>
       </itemizedlist>


### PR DESCRIPTION
This was added initially to match the output of `dpkg --print-architecture` exactly, but doing so makes no sense.

See: https://bugzilla.suse.com/show_bug.cgi?id=1212223


### Are there any relevant issues/feature requests?

* bsc#1212223
