### PR TITLE
Fix command to enable lingering

### DIFF
--- a/tasks/podman-autostarting-containers.xml
+++ b/tasks/podman-autostarting-containers.xml
@@ -82,7 +82,7 @@ CONTAINER ID  IMAGE [...]                                    NAMES
         mechanism is called <emphasis>lingering</emphasis> and is achieved by
         the following command:
       </para>
-<screen>&prompt.sudo;<command> <replaceable>USER_NAME</replaceable></command>
+<screen>&prompt.sudo;<command>loginctl enable-linger <replaceable>USER_NAME</replaceable></command></screen>
 </screen>
     </step>
     <step>


### PR DESCRIPTION
### Description

The command to enable user lingering seems incorrect (or just incomplete). You can see an example of the correct command in the [systems timers](https://github.com/SUSE/doc-modular/blob/f2dc9a5144a471c5248dc0d73a0094d04c83a93c/tasks/systemd-timer-user.xml#L59) section.