### PR TITLE
Create new article on sudo administration/configuration

### DIFF
--- a/DC-sudo-configure-superuser-privileges
+++ b/DC-sudo-configure-superuser-privileges
@@ -1,0 +1,19 @@
+## ---------------------------- 
+## Doc Config File for the DB Assembly test
+## ----------------------------
+##
+## Basics
+MAIN="sudo-configure-superuser-privileges.asm.xml"
+SRC_DIR="articles"
+IMG_SRC_DIR="images"
+
+## Profiling
+PROFOS="generic"
+#PROFARCH="x86_64;zseries;power;aarch64"
+
+## stylesheet location
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+
+DOCBOOK5_RNG_URI="urn:x-suse:rng:v2:geekodoc-flat"
+

--- a/articles/sudo-configure-superuser-privileges.asm.xml
+++ b/articles/sudo-configure-superuser-privileges.asm.xml
@@ -145,7 +145,7 @@ with &sudo;</meta>
                 It takes you up to 20 minutes to read through this article. 
                 Writing your first &sudo; configuration rule only takes a few 
                 minutes, but establishing a functioning  &sudo; configuration 
-                that works across your environment will take considerably longer 
+                that works across your environment will take considerably longer, 
                 depending on the complexity of your setup.
               </para>
             </listitem>

--- a/articles/sudo-configure-superuser-privileges.asm.xml
+++ b/articles/sudo-configure-superuser-privileges.asm.xml
@@ -39,7 +39,7 @@
       <resource xml:id="_sudo-without-root-password" href="../tasks/sudo-without-root-password.xml">
       <description>Using sudo without root password</description>
       </resource>
-      <resource xml:id="_sudo-troubleshooting" href="../references/sudo-troubleshoot.xml">
+      <resource xml:id="_sudo-troubleshooting" href="../tasks/sudo-troubleshoot.xml">
       <description>Troubleshooting sudo</description>
     </resource>
   </resources>

--- a/articles/sudo-configure-superuser-privileges.asm.xml
+++ b/articles/sudo-configure-superuser-privileges.asm.xml
@@ -20,11 +20,8 @@
   <!--Remove later: Please do an editorial and structural review of this module, irrespective of
     whether you see much changes in this module-->
   <resources>
-    <resource xml:id="_sudo-basic-concept" href="../concepts/sudo-concept.xml">
-      <description>Concept sudo</description>
-    </resource>
-    <resource xml:id="_difference-between-sudo-and-su" href="../concepts/difference-between-sudo-and-su.xml">
-      <description>Concept sudo</description>
+    <resource xml:id="_sudo-configuration-intro" href="../concepts/sudo-configuration-intro.xml">
+      <description>Introduction to sudo configuration</description>
     </resource>
   </resources>
 
@@ -186,8 +183,7 @@ with &sudo;</meta>
         </variablelist>
       </abstract>
     </merge>
-    <module resourceref="_sudo-basic-concept" renderas="section"/>
-    <module resourceref="_difference-between-sudo-and-su" renderas="section"/>
+    <module resourceref="_sudo-configuration-intro" renderas="section"/>
     <module resourceref="_sudo-user-authorization" renderas="section"/>
     <module resourceref="_sudo-edit-configuration" renderas="section"/>
     <module resourceref="_sudo-start-shell-as-root" renderas="section"/>

--- a/articles/sudo-configure-superuser-privileges.asm.xml
+++ b/articles/sudo-configure-superuser-privileges.asm.xml
@@ -46,7 +46,7 @@
   <!-- References -->
   <resources>
     <resource xml:id="_sudo-user-authorization" href="../references/sudo-user-authorization.xml">
-      <description>sudo configuration basics</description>
+      <description>sudo configuration reference</description>
     </resource>
     <resource xml:id="_sudo-edit-configuration" href="../references/sudo-edit-configuration.xml">
       <description>Maintaining sudo configuration files</description>
@@ -188,13 +188,13 @@ with &sudo;</meta>
     </merge>
     <module resourceref="_sudo-configuration-intro" renderas="section"/>
     <module resourceref="_sudo-creating-custom-configuration" renderas="section"/>
-    <module resourceref="_sudo-user-authorization" renderas="section"/>
     <module resourceref="_sudo-edit-configuration" renderas="section"/>
     <module resourceref="_sudo-start-shell-as-root" renderas="section"/>
     <module resourceref="_sudo-change-pw-timeout" renderas="section"/>
     <module resourceref="_sudo-without-root-password" renderas="section"/>
     <module resourceref="_sudo-best-practices" renderas="section"/>
     <module resourceref="_sudo-troubleshooting" renderas="section"/>
+    <module resourceref="_sudo-user-authorization" renderas="section"/>
     <module resourceref="_legal" renderas="section"/>
     <module resourceref="_gfdl" renderas="appendix"/>
   </structure>

--- a/articles/sudo-configure-superuser-privileges.asm.xml
+++ b/articles/sudo-configure-superuser-privileges.asm.xml
@@ -36,14 +36,12 @@
      <resource xml:id="_sudo-change-pw-timeout" href="../tasks/sudo-change-pw-timeout.xml">
       <description>Changing the sudo password prompt time-out</description>
       </resource>
-<!--<resource xml:id="_sudo-manage-wheel-group" href="../tasks/sudo-manage-wheel-group.xml">
-      <description>Managing the
-      <systemitem class="groupname">wheel</systemitem> user group for sudo
-      privileges</description>
-      </resource>-->
       <resource xml:id="_sudo-without-root-password" href="../tasks/sudo-without-root-password.xml">
       <description>Using sudo without root password</description>
       </resource>
+      <resource xml:id="_sudo-troubleshooting" href="../references/sudo-troubleshoot.xml">
+      <description>Troubleshooting sudo</description>
+    </resource>
   </resources>
   <!-- References -->
   <resources>
@@ -52,9 +50,6 @@
     </resource>
     <resource xml:id="_sudo-edit-configuration" href="../references/sudo-edit-configuration.xml">
       <description>Maintaining sudo configuration files</description>
-    </resource>
-    <resource xml:id="_sudo-troubleshooting" href="../references/sudo-troubleshoot.xml">
-      <description>Troubleshooting sudo</description>
     </resource>
     <resource xml:id="_sudo-best-practices" href="../references/sudo-best-practices.xml">
       <description>sudo best practices</description>

--- a/articles/sudo-configure-superuser-privileges.asm.xml
+++ b/articles/sudo-configure-superuser-privileges.asm.xml
@@ -110,9 +110,8 @@ its:translate="no"/>
       </meta>
       <meta name="title" its:translate="yes">Configuring superuser privileges
 with &sudo;</meta>
-      <meta name="description" its:translate="yes">Get familiar basic &sudo; 
-      configuration and learn how delegate superuser privileges with &sudo; 
-      for the most common use cases.
+      <meta name="description" its:translate="yes">Learn how to delegate 
+      superuser privileges with &sudo;.
      </meta>
       <meta name="social-descr" its:translate="yes">Learn how to configure 
       superuser privileges with &sudo;</meta>
@@ -145,9 +144,9 @@ with &sudo;</meta>
               <para>
                 It takes you up to 20 minutes to read through this article. 
                 Writing your first &sudo; configuration rule only takes a few 
-                minutes, but establishing a functioning framework of &sudo; 
-                configurations that work across your environment will take 
-                considerably longer depending on the complexity of your setup.
+                minutes, but establishing a functioning  &sudo; configuration 
+                that works across your environment will take considerably longer 
+                depending on the complexity of your setup.
               </para>
             </listitem>
         </varlistentry>

--- a/articles/sudo-configure-superuser-privileges.asm.xml
+++ b/articles/sudo-configure-superuser-privileges.asm.xml
@@ -27,6 +27,9 @@
 
    <!-- Tasks -->
   <resources>
+    <resource xml:id="_sudo-creating-custom-configuration" href="../tasks/sudo-creating-custom-configuration.xml">
+      <description>Creating a custom sudo configuration</description>
+    </resource>
     <resource xml:id="_sudo-start-shell-as-root" href="../tasks/sudo-start-shell-as-root.xml">
       <description>Starting a shell with root privileges </description>
     </resource>
@@ -168,7 +171,7 @@ with &sudo;</meta>
                 </listitem>
                 <listitem>
                   <para>
-                    &rootuser; privileges.
+                    &rootuser; privileges. To use &sudo; as a normal user, refer to ???.
                   </para>
                 </listitem>
                 <listitem>
@@ -184,6 +187,7 @@ with &sudo;</meta>
       </abstract>
     </merge>
     <module resourceref="_sudo-configuration-intro" renderas="section"/>
+    <module resourceref="_sudo-creating-custom-configuration" renderas="section"/>
     <module resourceref="_sudo-user-authorization" renderas="section"/>
     <module resourceref="_sudo-edit-configuration" renderas="section"/>
     <module resourceref="_sudo-start-shell-as-root" renderas="section"/>

--- a/articles/sudo-configure-superuser-privileges.asm.xml
+++ b/articles/sudo-configure-superuser-privileges.asm.xml
@@ -171,8 +171,8 @@ with &sudo;</meta>
                 </listitem>
                 <listitem>
                   <para>
-                    &rootuser; privileges. To use &sudo; as a normal user, refer 
-                    to <link xlink:href="https://documentation.suse.com/smart/systems-management/html/sudo-run-commands-as-superuser/index.html"/>.
+                    &rootuser; privileges. For information on how to use &sudo; 
+                    as a normal user, refer to <link xlink:href="https://documentation.suse.com/smart/systems-management/html/sudo-run-commands-as-superuser/index.html"/>.
                   </para>
                 </listitem>
                 <listitem>
@@ -188,9 +188,9 @@ with &sudo;</meta>
     </merge>
     <module resourceref="_sudo-configuration-intro" renderas="section"/>
     <module resourceref="_sudo-creating-custom-configuration" renderas="section"/>
-    <module resourceref="_sudo-start-shell-as-root" renderas="section"/>
-    <module resourceref="_sudo-change-pw-timeout" renderas="section"/>
     <module resourceref="_sudo-without-root-password" renderas="section"/>
+    <module resourceref="_sudo-change-pw-timeout" renderas="section"/>
+    <module resourceref="_sudo-start-shell-as-root" renderas="section"/>
     <module resourceref="_sudo-best-practices" renderas="section"/>
     <module resourceref="_sudo-troubleshooting" renderas="section"/>
     <module resourceref="_sudo-user-authorization" renderas="section"/>

--- a/articles/sudo-configure-superuser-privileges.asm.xml
+++ b/articles/sudo-configure-superuser-privileges.asm.xml
@@ -171,7 +171,8 @@ with &sudo;</meta>
                 </listitem>
                 <listitem>
                   <para>
-                    &rootuser; privileges. To use &sudo; as a normal user, refer to ???.
+                    &rootuser; privileges. To use &sudo; as a normal user, refer 
+                    to <link xlink:href="https://documentation.suse.com/smart/systems-management/html/sudo-run-commands-as-superuser/index.html"/>.
                   </para>
                 </listitem>
                 <listitem>

--- a/articles/sudo-configure-superuser-privileges.asm.xml
+++ b/articles/sudo-configure-superuser-privileges.asm.xml
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml-model href="https://cdn.docbook.org/schema/5.2/rng/assemblyxi.rnc"
+            type="application/relax-ng-compact-syntax"?>
+<!DOCTYPE assembly
+[
+    <!ENTITY % entities SYSTEM "../common/generic-entities.ent">
+    %entities;
+]>
+<!-- refers to legacy doc: https://github.com/SUSE/doc-sle/blob/main/xml/adm_sudo.xml -->
+
+<assembly version="5.2" xml:lang="en"
+          xmlns:xlink="http://www.w3.org/1999/xlink"
+          xmlns:trans="http://docbook.org/ns/transclusion"
+          xmlns:its="http://www.w3.org/2005/11/its"
+          xmlns="http://docbook.org/ns/docbook">
+  <!-- resources section references all topic chunks used in the final article
+    -->
+  <!-- R E S O U R C E S -->
+  <!-- Concept files -->
+  <!--Remove later: Please do an editorial and structural review of this module, irrespective of
+    whether you see much changes in this module-->
+  <resources>
+    <resource xml:id="_sudo-basic-concept" href="../concepts/sudo-concept.xml">
+      <description>Concept sudo</description>
+    </resource>
+    <resource xml:id="_difference-between-sudo-and-su" href="../concepts/difference-between-sudo-and-su.xml">
+      <description>Concept sudo</description>
+    </resource>
+  </resources>
+
+   <!-- Tasks -->
+  <resources>
+    <resource xml:id="_sudo-start-shell-as-root" href="../tasks/sudo-start-shell-as-root.xml">
+      <description>Starting a shell with root privileges </description>
+    </resource>
+     <resource xml:id="_sudo-change-pw-timeout" href="../tasks/sudo-change-pw-timeout.xml">
+      <description>Changing the sudo password prompt time-out</description>
+      </resource>
+<!--<resource xml:id="_sudo-manage-wheel-group" href="../tasks/sudo-manage-wheel-group.xml">
+      <description>Managing the
+      <systemitem class="groupname">wheel</systemitem> user group for sudo
+      privileges</description>
+      </resource>-->
+      <resource xml:id="_sudo-without-root-password" href="../tasks/sudo-without-root-password.xml">
+      <description>Using sudo without root password</description>
+      </resource>
+  </resources>
+  <!-- References -->
+  <resources>
+    <resource xml:id="_sudo-user-authorization" href="../references/sudo-user-authorization.xml">
+      <description>sudo configuration basics</description>
+    </resource>
+    <resource xml:id="_sudo-edit-configuration" href="../references/sudo-edit-configuration.xml">
+      <description>Maintaining sudo configuration files</description>
+    </resource>
+    <resource xml:id="_sudo-troubleshooting" href="../references/sudo-troubleshoot.xml">
+      <description>Troubleshooting sudo</description>
+    </resource>
+    <resource xml:id="_sudo-best-practices" href="../references/sudo-best-practices.xml">
+      <description>sudo best practices</description>
+    </resource>
+  </resources>
+      <!-- Miscellaneous -->
+  <resources>
+    <resource href="../common/legal.xml" xml:id="_legal"/>
+    <resource href="../common/license_gfdl1.2.xml" xml:id="_gfdl"/>
+  </resources>
+  <!-- S T R U C T U R E -->
+  <structure renderas="article" xml:id="sudo-configure-superuser-privileges" xml:lang="en">
+    <merge>
+      <title>Configuring superuser privileges with &sudo;</title>
+      <!-- Create changelog to enable versioning; add most recent entries at the top. -->
+      <revhistory>
+        <title>Changelog</title>
+        <revision><revnumber>1</revnumber><date>2023-10-06</date>
+          <revdescription>
+            <para>
+              Initial version
+            </para>
+          </revdescription>
+        </revision>
+      </revhistory>
+      <!-- TODO: provide a listing of possible and validatable meta entry values. Maybe in our geekodoc repo? -->
+      <!-- add author's e-mail -->
+      <meta name="maintainer" content="jana.jaeger@suse.com" its:translate="no"/>
+      <!-- ISO date of last update as YYYY-MM-DD -->
+      <meta name="updated" content="2023-10-06" its:translate="no"/>
+      <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+        <dm:bugtracker>
+          <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
+          <dm:component>Smart Docs</dm:component>
+          <dm:product>Documentation</dm:product>
+          <dm:assignee>fs@suse.com</dm:assignee>
+        </dm:bugtracker>
+        <dm:translation>yes</dm:translation>
+      </dm:docmanager>
+      <!--<meta name="translation" its:translate="no">
+         enter yes or no for translation <phrase role="trans">yes</phrase>
+         enter languages: ar-ar, cs-cz, ... <phrase role="language">de-de</phrase>
+      </meta>-->
+
+      <!-- enter the platform identifier or a list of
+        identifiers, separated by ; -->
+      <meta name="architecture" content="x86_64;zseries;power;aarch64"
+its:translate="no"/>
+       <meta name="productname" its:translate="no">
+        <productname version="1">&alp;</productname>
+        <productname version="15-SP5">&sles;</productname>
+        <productname version="15-SP4">&sles;</productname>
+        <productname version="15-SP3">&sles;</productname>
+        <productname version="15-SP2">&sles;</productname>
+        <productname version="15-SP1">&sles;</productname>
+        <productname version="15-GA">&sles;</productname>
+      </meta>
+      <meta name="title" its:translate="yes">Configuring superuser privileges
+with &sudo;</meta>
+      <meta name="description" its:translate="yes">Get familiar basic &sudo; 
+      configuration and learn how delegate superuser privileges with &sudo; 
+      for the most common use cases.
+     </meta>
+      <meta name="social-descr" its:translate="yes">Learn how to configure 
+      superuser privileges with &sudo;</meta>
+      <!-- suitable category, comma-separated list of categories -->
+      <meta name="category" content="Systems Management" its:translate="no"/>
+      <abstract>
+        <variablelist>
+        <varlistentry>
+          <term>WHAT?</term>
+          <listitem>
+            <para>
+              Get familiar with basic &sudo; configuration and learn how delegate 
+              superuser privileges with &sudo; for the most common use cases.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>WHY?</term>
+          <listitem>
+            <para>
+              Some commands require administrator or &rootuser; privileges. 
+              Using &sudo; you can delegate the privileges to execute these 
+              commands to certain users or groups of users.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>EFFORT</term>
+            <listitem>
+              <para>
+                It takes you up to 20 minutes to read through this article. If
+                you have a specific question, you can jump directly to the
+                respective chapter.
+              </para>
+            </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>GOAL</term>
+            <listitem>
+              <para>
+                Understand the basic aspects of &sudo; configuration. Address a 
+                common use cases for &sudo; configuration. Learn how to 
+                work with users, user groups and aliases to securely and 
+                efficiently set up &sudo; in your environment. Famliarize 
+                yourself with &sudo; best practices and troubleshooting.
+              </para>
+            </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>REQUIREMENTS</term>
+            <listitem>
+              <itemizedlist>
+                <listitem>
+                  <para>
+                    Basic understanding of &sudo;.
+                  </para>
+                </listitem>
+                <listitem>
+                  <para>
+                    &rootuser; privileges.
+                  </para>
+                </listitem>
+                <listitem>
+                <para>
+                The <package>sudo</package> package needs to be installed.
+                This package is available on &productname; by default.
+                </para>
+                </listitem>
+              </itemizedlist>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+      </abstract>
+    </merge>
+    <module resourceref="_sudo-basic-concept" renderas="section"/>
+    <module resourceref="_difference-between-sudo-and-su" renderas="section"/>
+    <module resourceref="_sudo-user-authorization" renderas="section"/>
+    <module resourceref="_sudo-edit-configuration" renderas="section"/>
+    <module resourceref="_sudo-start-shell-as-root" renderas="section"/>
+    <module resourceref="_sudo-change-pw-timeout" renderas="section"/>
+    <module resourceref="_sudo-without-root-password" renderas="section"/>
+    <module resourceref="_sudo-best-practices" renderas="section"/>
+    <module resourceref="_sudo-troubleshooting" renderas="section"/>
+    <module resourceref="_legal" renderas="section"/>
+    <module resourceref="_gfdl" renderas="appendix"/>
+  </structure>
+</assembly>

--- a/articles/sudo-configure-superuser-privileges.asm.xml
+++ b/articles/sudo-configure-superuser-privileges.asm.xml
@@ -124,8 +124,8 @@ with &sudo;</meta>
           <term>WHAT?</term>
           <listitem>
             <para>
-              Get familiar with basic &sudo; configuration and learn how delegate 
-              superuser privileges with &sudo;.
+              Get familiar with the basics of &sudo; configuration and learn how 
+              delegate superuser privileges with &sudo;.
             </para>
           </listitem>
         </varlistentry>
@@ -134,8 +134,8 @@ with &sudo;</meta>
           <listitem>
             <para>
               Some commands require administrator or &rootuser; privileges. 
-              Using &sudo; you can delegate the privileges to execute these 
-              commands to certain users or groups of users.
+              Using &sudo;, you can delegate the privileges to execute these 
+              commands to certain users or groups.
             </para>
           </listitem>
         </varlistentry>
@@ -144,8 +144,8 @@ with &sudo;</meta>
             <listitem>
               <para>
                 It takes you up to 20 minutes to read through this article. 
-                Writing your first &sudo; configuration rule will only take a 
-                few minutes, but establishing a functioning framework of &sudo; 
+                Writing your first &sudo; configuration rule only takes a few 
+                minutes, but establishing a functioning framework of &sudo; 
                 configurations that work across your environment will take 
                 considerably longer depending on the complexity of your setup.
               </para>

--- a/articles/sudo-configure-superuser-privileges.asm.xml
+++ b/articles/sudo-configure-superuser-privileges.asm.xml
@@ -96,7 +96,7 @@
       <meta name="architecture" content="x86_64;zseries;power;aarch64"
 its:translate="no"/>
        <meta name="productname" its:translate="no">
-        <productname version="1">&alp;</productname>
+        <!-- <productname version="1">&alp;</productname> -->
         <productname version="15-SP5">&sles;</productname>
         <productname version="15-SP4">&sles;</productname>
         <productname version="15-SP3">&sles;</productname>

--- a/articles/sudo-configure-superuser-privileges.asm.xml
+++ b/articles/sudo-configure-superuser-privileges.asm.xml
@@ -143,9 +143,11 @@ with &sudo;</meta>
           <term>EFFORT</term>
             <listitem>
               <para>
-                It takes you up to 20 minutes to read through this article. If
-                you have a specific question, you can jump directly to the
-                respective chapter.
+                It takes you up to 20 minutes to read through this article. 
+                Writing your first &sudo; configuration rule will only take a 
+                few minutes, but establishing a functioning framework of &sudo; 
+                configurations that work across your environment will take 
+                considerably longer depending on the complexity of your setup.
               </para>
             </listitem>
         </varlistentry>
@@ -153,9 +155,9 @@ with &sudo;</meta>
           <term>GOAL</term>
             <listitem>
               <para>
-                Understand the basic aspects of &sudo; configuration. Address a 
-                common use cases for &sudo; configuration. Learn how to 
-                work with users, user groups and aliases to set up &sudo;. 
+                Understand the basic aspects of &sudo; configuration. Address 
+                common use cases for &sudo; configuration. Learn how to work 
+                with users, user groups and aliases in &sudo; setups.
                 Famliarize yourself with &sudo; best practices and troubleshooting.
               </para>
             </listitem>

--- a/articles/sudo-configure-superuser-privileges.asm.xml
+++ b/articles/sudo-configure-superuser-privileges.asm.xml
@@ -125,7 +125,7 @@ with &sudo;</meta>
           <listitem>
             <para>
               Get familiar with basic &sudo; configuration and learn how delegate 
-              superuser privileges with &sudo; for the most common use cases.
+              superuser privileges with &sudo;.
             </para>
           </listitem>
         </varlistentry>
@@ -155,9 +155,8 @@ with &sudo;</meta>
               <para>
                 Understand the basic aspects of &sudo; configuration. Address a 
                 common use cases for &sudo; configuration. Learn how to 
-                work with users, user groups and aliases to securely and 
-                efficiently set up &sudo; in your environment. Famliarize 
-                yourself with &sudo; best practices and troubleshooting.
+                work with users, user groups and aliases to set up &sudo;. 
+                Famliarize yourself with &sudo; best practices and troubleshooting.
               </para>
             </listitem>
         </varlistentry>
@@ -177,8 +176,7 @@ with &sudo;</meta>
                 </listitem>
                 <listitem>
                 <para>
-                The <package>sudo</package> package needs to be installed.
-                This package is available on &productname; by default.
+                  The <package>sudo</package> package needs to be installed.
                 </para>
                 </listitem>
               </itemizedlist>
@@ -189,9 +187,6 @@ with &sudo;</meta>
     </merge>
     <module resourceref="_sudo-configuration-intro" renderas="section"/>
     <module resourceref="_sudo-creating-custom-configuration" renderas="section"/>
-    <!--
-    <module resourceref="_sudo-edit-configuration" renderas="section"/>
-    -->
     <module resourceref="_sudo-start-shell-as-root" renderas="section"/>
     <module resourceref="_sudo-change-pw-timeout" renderas="section"/>
     <module resourceref="_sudo-without-root-password" renderas="section"/>

--- a/articles/sudo-configure-superuser-privileges.asm.xml
+++ b/articles/sudo-configure-superuser-privileges.asm.xml
@@ -157,7 +157,7 @@ with &sudo;</meta>
                 Understand the basic aspects of &sudo; configuration. Address 
                 common use cases for &sudo; configuration. Learn how to work 
                 with users, user groups and aliases in &sudo; setups.
-                Famliarize yourself with &sudo; best practices and troubleshooting.
+                Familiarize yourself with &sudo; best practices and troubleshooting.
               </para>
             </listitem>
         </varlistentry>

--- a/articles/sudo-configure-superuser-privileges.asm.xml
+++ b/articles/sudo-configure-superuser-privileges.asm.xml
@@ -48,9 +48,10 @@
     <resource xml:id="_sudo-user-authorization" href="../references/sudo-user-authorization.xml">
       <description>sudo configuration reference</description>
     </resource>
+    <!--
     <resource xml:id="_sudo-edit-configuration" href="../references/sudo-edit-configuration.xml">
       <description>Maintaining sudo configuration files</description>
-    </resource>
+    </resource> -->
     <resource xml:id="_sudo-best-practices" href="../references/sudo-best-practices.xml">
       <description>sudo best practices</description>
     </resource>
@@ -188,7 +189,9 @@ with &sudo;</meta>
     </merge>
     <module resourceref="_sudo-configuration-intro" renderas="section"/>
     <module resourceref="_sudo-creating-custom-configuration" renderas="section"/>
+    <!--
     <module resourceref="_sudo-edit-configuration" renderas="section"/>
+    -->
     <module resourceref="_sudo-start-shell-as-root" renderas="section"/>
     <module resourceref="_sudo-change-pw-timeout" renderas="section"/>
     <module resourceref="_sudo-without-root-password" renderas="section"/>

--- a/concepts/sudo-configuration-intro.xml
+++ b/concepts/sudo-configuration-intro.xml
@@ -47,7 +47,7 @@
           <para>
             &sudo; offers a fine-grained control over users, groups, hosts and
              commands and thus increases system security by reducing the risk of
-             malicious or accidental damage by either and intruder or a 
+             malicious or accidental damage by an intruder or a 
              system user.
           </para>
         </listitem>

--- a/concepts/sudo-configuration-intro.xml
+++ b/concepts/sudo-configuration-intro.xml
@@ -26,8 +26,7 @@
       </para>
     </abstract>
   </info>
-  <section xml:id="sudo-configure-intro-why">
-    <title>Why use &sudo; to delegate &rootuser; privileges?</title>
+
     <para>
       Certain operations on a Linux system require &rootuser; or administrator 
       privileges. A home user who administers their own system proably will not 
@@ -39,7 +38,7 @@
       with the necessary privileges to carry out their tasks.
     </para>
     <para>
-      &sudo; provides exactly that:
+      &sudo; provides:
     </para>
     <variablelist>
       <varlistentry>
@@ -74,9 +73,6 @@
         </listitem>
       </varlistentry>
     </variablelist>
-  </section>
-  <section xml:id="sudo-configure-intro-how">
-    <title>How does &sudo; configuration work?</title>
     <para>
       The main &sudo; configuration file is called 
       <filename>/etc/sudoers</filename>. This file contains a basic set of 
@@ -84,5 +80,4 @@
       located under <filename>/etc/sudoers.d/</filename>.
     </para>
     <!-- add general blurb on security, importance of testing and allowlists vs. using groups-->
-  </section>
 </topic>

--- a/concepts/sudo-configuration-intro.xml
+++ b/concepts/sudo-configuration-intro.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+[
+  <!ENTITY % entities SYSTEM "../common/generic-entities.ent">
+    %entities;
+]>
+<!-- refers to legacy doc: <add github link to legacy doc piece, if applicable> -->
+<!-- point back to this document with a similar comment added to your legacy doc piece -->
+<!-- refer to README.md for file and id naming conventions -->
+<!-- metadata is dealt with on the assembly level -->
+<topic xml:id="sudo-configure-intro"
+ role="concept" xml:lang="en"
+ xmlns="http://docbook.org/ns/docbook" version="5.2"
+ xmlns:its="http://www.w3.org/2005/11/its"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink"
+ xmlns:trans="http://docbook.org/ns/transclusion">
+  <info>
+    <title>An introduction to &sudo; configuration</title><!-- can be changed via merge in the assembly -->
+    <!--add author's email address-->
+    <meta name="maintainer" content="jana.jaeger@suse.com" its:translate="no"/>
+    <abstract><!-- can be changed via merge in the assembly -->
+      <para>
+       &sudo; provides a means to securely and efficiently delegate superuser 
+       privileges to specific users or groups, if configured accordingly.
+      </para>
+    </abstract>
+  </info>
+  <section xml:id="sudo-configure-intro-why">
+    <title>Why use &sudo; to delegate &rootuser; privileges?</title>
+    <para>
+      Certain operations on a Linux system require &rootuser; or administrator 
+      privileges. A home user who administers their own system proably will not 
+      ever worry about delegating superuser privileges, because administrator 
+      and normal user are one and the same person. But as soon as a system is 
+      part of a larger systems environment with multiple users, groups and and 
+      hosts, it becomes vital to maintain control of who is allowed to do what 
+      and where. At the same time it important to provide all users and groups 
+      with the necessary privileges to carry out their tasks.
+    </para>
+    <para>
+      &sudo; provides exactly that:
+    </para>
+    <variablelist>
+      <varlistentry>
+        <term>Enhanced system security</term>
+        <listitem>
+          <para>
+            &sudo; provides a fine-grained control over users, groups, hosts and
+             commands and thus increases system security by reducing the risk of
+             malicious or accidental damage by either and intruder or a 
+             system user.
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>Complete audit trail</term>
+        <listitem>
+          <para>
+            Whenever a user switches privileges, this is appears in the system's 
+            log and all operations carried out by this user with elevated 
+            privileges can be traced back to them.
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>Delegate &rootuser;-specific tasks</term>
+        <listitem>
+          <para>
+            Using &sudo;, system administrators can enable single users or 
+            groups to carry out certain tasks without the need to enter 
+            the &rootuser; password and switch to the &rootuser; account.
+          </para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+  </section>
+  <section xml:id="sudo-configure-intro-how">
+    <title>How does &sudo; configuration work?</title>
+    <para>
+      The main &sudo; configuration file is called 
+      <filename>/etc/sudoers</filename>. This file contains a basic set of 
+      preset values and a directive to include user-made custom configurations 
+      located under <filename>/etc/sudoers.d/</filename>.
+    </para>
+    <para>
+      Any changes to the &sudo; configuration should be done using the 
+      <command>visudo</command>. <command>visudo</command> is a tailor-made tool 
+      that allows you to edit the &sudo; configuration files and that runs basic 
+      synthax checks making sure that the configuration remains intact and 
+      functional. A faulty &sudo; configuration can result in a user being 
+      locked out of their own system.
+    </para>
+  </section>
+</topic>

--- a/concepts/sudo-configuration-intro.xml
+++ b/concepts/sudo-configuration-intro.xml
@@ -29,10 +29,10 @@
 
     <para>
       Certain operations on a Linux system require &rootuser; or administrator 
-      privileges. Home user who administer their own system will not 
-      ever worry about delegating superuser privileges, because administrator 
-      and normal user are one and the same person in this scenario. But as soon 
-      as a system is part of a larger systems environment with multiple users, 
+      privileges. Home users who administer their own system do not have to 
+      delegate superuser privileges, because the administrator and the normal
+      user are the same person in this scenario. But as soon as a system is part
+      of a larger systems environment with multiple users, 
       groups and hosts, it becomes vital to maintain control of who is allowed 
       to do what and where. At the same time, it is important to provide all 
       users and groups with the necessary privileges to carry out their tasks.

--- a/concepts/sudo-configuration-intro.xml
+++ b/concepts/sudo-configuration-intro.xml
@@ -78,7 +78,7 @@
       <para>
         This article provides in-depth &sudo; configuration information. It does 
         not, however, provide any advice on how to build a comprehensive and and 
-        secure &sudo; policy. Security policies tend to be very complex and 
+        secure &sudo; policy. Security-related policies are very complex and 
         strongly depend on the environment they are created for.
       </para>
     </important>

--- a/concepts/sudo-configuration-intro.xml
+++ b/concepts/sudo-configuration-intro.xml
@@ -56,8 +56,8 @@
         <term>Complete audit trail</term>
         <listitem>
           <para>
-            Whenever a user switches privileges, this is appears in the system's 
-            log and all operations carried out by this user with elevated 
+            Whenever a user switches privileges, this appears in the system's 
+            log, and all operations carried out by this user with elevated 
             privileges can be traced back to them.
           </para>
         </listitem>

--- a/concepts/sudo-configuration-intro.xml
+++ b/concepts/sudo-configuration-intro.xml
@@ -22,30 +22,30 @@
     <abstract><!-- can be changed via merge in the assembly -->
       <para>
        &sudo; provides a means to securely and efficiently delegate superuser 
-       privileges to specific users or groups, if configured accordingly.
+       privileges to specific users or groups.
       </para>
     </abstract>
   </info>
 
     <para>
       Certain operations on a Linux system require &rootuser; or administrator 
-      privileges. A home user who administers their own system proably will not 
+      privileges. A home user who administers their own system will not 
       ever worry about delegating superuser privileges, because administrator 
-      and normal user are one and the same person. But as soon as a system is 
-      part of a larger systems environment with multiple users, groups and and 
-      hosts, it becomes vital to maintain control of who is allowed to do what 
-      and where. At the same time it important to provide all users and groups 
-      with the necessary privileges to carry out their tasks.
+      and normal user are one and the same person in this scenario. But as soon 
+      as a system is part of a larger systems environment with multiple users, 
+      groups and hosts, it becomes vital to maintain control of who is allowed 
+      to do what and where. At the same time, it is important to provide all 
+      users and groups with the necessary privileges to carry out their tasks.
     </para>
     <para>
-      &sudo; provides:
+      &sudo; is designed to help with this. It provides:
     </para>
     <variablelist>
       <varlistentry>
         <term>Enhanced system security</term>
         <listitem>
           <para>
-            &sudo; provides a fine-grained control over users, groups, hosts and
+            &sudo; offers a fine-grained control over users, groups, hosts and
              commands and thus increases system security by reducing the risk of
              malicious or accidental damage by either and intruder or a 
              system user.

--- a/concepts/sudo-configuration-intro.xml
+++ b/concepts/sudo-configuration-intro.xml
@@ -63,7 +63,7 @@
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term>Delegate &rootuser;-specific tasks</term>
+        <term>A means to delegate &rootuser;-specific tasks</term>
         <listitem>
           <para>
             Using &sudo;, system administrators can enable single users or 

--- a/concepts/sudo-configuration-intro.xml
+++ b/concepts/sudo-configuration-intro.xml
@@ -83,13 +83,5 @@
       preset values and a directive to include user-made custom configurations 
       located under <filename>/etc/sudoers.d/</filename>.
     </para>
-    <para>
-      Any changes to the &sudo; configuration should be done using the 
-      <command>visudo</command>. <command>visudo</command> is a tailor-made tool 
-      that allows you to edit the &sudo; configuration files and that runs basic 
-      synthax checks making sure that the configuration remains intact and 
-      functional. A faulty &sudo; configuration can result in a user being 
-      locked out of their own system.
-    </para>
   </section>
 </topic>

--- a/concepts/sudo-configuration-intro.xml
+++ b/concepts/sudo-configuration-intro.xml
@@ -73,11 +73,13 @@
         </listitem>
       </varlistentry>
     </variablelist>
-    <para>
-      The main &sudo; configuration file is called 
-      <filename>/etc/sudoers</filename>. This file contains a basic set of 
-      preset values and a directive to include user-made custom configurations 
-      located under <filename>/etc/sudoers.d/</filename>.
-    </para>
-    <!-- add general blurb on security, importance of testing and allowlists vs. using groups-->
+    <important>
+      <title>How to read this article</title>
+      <para>
+        This article provides in-depth &sudo; configuration information. It does 
+        not, however, provide any advice on how to build a comprehensive and and 
+        secure &sudo; policy. Security policies tend to be very complex and 
+        strongly depend on the environment they are created for.
+      </para>
+    </important>
 </topic>

--- a/concepts/sudo-configuration-intro.xml
+++ b/concepts/sudo-configuration-intro.xml
@@ -83,5 +83,6 @@
       preset values and a directive to include user-made custom configurations 
       located under <filename>/etc/sudoers.d/</filename>.
     </para>
+    <!-- add general blurb on security, importance of testing and allowlists vs. using groups-->
   </section>
 </topic>

--- a/concepts/sudo-configuration-intro.xml
+++ b/concepts/sudo-configuration-intro.xml
@@ -29,7 +29,7 @@
 
     <para>
       Certain operations on a Linux system require &rootuser; or administrator 
-      privileges. A home user who administers their own system will not 
+      privileges. Home user who administer their own system will not 
       ever worry about delegating superuser privileges, because administrator 
       and normal user are one and the same person in this scenario. But as soon 
       as a system is part of a larger systems environment with multiple users, 

--- a/concepts/sudo-configuration-intro.xml
+++ b/concepts/sudo-configuration-intro.xml
@@ -45,7 +45,7 @@
         <term>Enhanced system security</term>
         <listitem>
           <para>
-            &sudo; offers a fine-grained control over users, groups, hosts and
+            &sudo; offers fine-grained control over users, groups, hosts and
              commands and thus increases system security by reducing the risk of
              malicious or accidental damage by an intruder or a 
              system user.

--- a/concepts/sudo-configuration-intro.xml
+++ b/concepts/sudo-configuration-intro.xml
@@ -76,9 +76,9 @@
     <important>
       <title>How to read this article</title>
       <para>
-        This article provides in-depth &sudo; configuration information. It does 
-        not, however, provide any advice on how to build a comprehensive and and 
-        secure &sudo; policy. Security-related policies are very complex and 
+        This article provides in-depth &sudo; configuration information. 
+        However, it does not provide any advice on how to build a comprehensive 
+        and secure &sudo; policy. Security-related policies are very complex and 
         strongly depend on the environment they are created for.
       </para>
     </important>

--- a/references/sudo-best-practices.xml
+++ b/references/sudo-best-practices.xml
@@ -37,8 +37,8 @@
             create separate configuration files holding your custom settings
             under the<filename>/etc/sudoers.d/</filename> directory. These are
             pulled in by default by a directive in
-            <filename>/etc/sudoers</filename>. For more information, refer to
-            <xref linkend="sudo-edit-configuration-custom"/>.
+            <filename>/etc/sudoers</filename>. <!-- For more information, refer to
+            <xref linkend="sudo-edit-configuration-custom"/>.-->
           </para>
         </listitem>
       </varlistentry>
@@ -59,8 +59,7 @@
           <para>
            Use the <command>visudo</command> command to safely edit the <filename>/etc/sudoers</filename> file, as it checks the syntax of the file
            before saving the changes. This is a preventive way to correct any errors that can break the system.
-           For more information, refer to <xref linkend="sudo-edit-configuration-visudo"/>
-
+           <!-- For more information, refer to <xref linkend="sudo-edit-configuration-visudo"/> -->
           </para>
         </listitem>
       </varlistentry>

--- a/references/sudo-best-practices.xml
+++ b/references/sudo-best-practices.xml
@@ -72,8 +72,8 @@
            <filename>/etc/sudoers</filename> file, because it checks the syntax of 
            the file before saving the changes. This is a preventive way to 
            correct any errors that can break the system.
-           In addition to the basic syntax check, you can also run 
-           <command>visudo -c</command> to check whether your entire framwork of
+           Besides the basic syntax check, you can also run 
+           <command>visudo -c</command> to check whether your entire framework of
            &sudo; configuration is parsed in the right order and without an error.
           </para>
         </listitem>

--- a/references/sudo-best-practices.xml
+++ b/references/sudo-best-practices.xml
@@ -32,8 +32,8 @@
         <listitem>
           <para>
             To build a truly efficient and secure &sudo; configuration framework, 
-            establish a routine of regular testing and auditing. Make sure that
-            possible loopholes are found and dealt with. Do not let convenience 
+            establish a routine of regular testing and auditing. Make sure to 
+            identiry possible loopholes and deal with them. Do not let convenience 
             trump security.
           </para>
         </listitem>
@@ -57,7 +57,7 @@
         <term>Limit the &sudo; time-out</term>
         <listitem>
           <para>
-            For security reasons you should not give unlimited access to
+            For security reasons, do not give unlimited access to
             &rootuser; privileges. Instead, set a reasonable time-out instead to prevent
             misuse of the &rootuser; account by any intruder. For more
             information, refer to <xref linkend="sudo-change-pw-timeout"/>.
@@ -120,8 +120,8 @@
         <term>Restrict the path for binaries</term>
         <listitem>
           <para>
-            Restrict the areas where users can execute commands using the
-            <literal>secure_path</literal> directive. The following example
+            With the <literal>secure_path</literal> directive, restrict the 
+            areas where users can execute commands. The following example
             is the default setting that ships with &productname;.
           </para>
           <screen>

--- a/references/sudo-best-practices.xml
+++ b/references/sudo-best-practices.xml
@@ -68,9 +68,13 @@
         <term>Use the <command>visudo</command> command</term>
         <listitem>
           <para>
-           Use the <command>visudo</command> command to safely edit the <filename>/etc/sudoers</filename> file, as it checks the syntax of the file
-           before saving the changes. This is a preventive way to correct any errors that can break the system.
-           <!-- For more information, refer to <xref linkend="sudo-edit-configuration-visudo"/> -->
+           Use the <command>visudo</command> command to safely edit the 
+           <filename>/etc/sudoers</filename> file, because it checks the syntax of 
+           the file before saving the changes. This is a preventive way to 
+           correct any errors that can break the system.
+           In addition to the basic syntax check, you can also run 
+           <command>visudo -c</command> to check whether your entire framwork of
+           &sudo; configuration is parsed in the right order and without an error.
           </para>
         </listitem>
       </varlistentry>

--- a/references/sudo-best-practices.xml
+++ b/references/sudo-best-practices.xml
@@ -17,7 +17,7 @@
  xmlns:trans="http://docbook.org/ns/transclusion">
 <info>
   <title>&sudo; best practices</title>
-    <meta name="maintainer" content="amrita.sakthivel@suse.com" its:translate="no"/>
+    <meta name="maintainer" content="jana.jaeger@suse.com" its:translate="no"/>
     <abstract>
      <!--Remove later: Please do an editorial and structural review of this module, irrespective of
     whether you see much changes in this module-->
@@ -27,6 +27,17 @@
     </abstract>
   </info>
    <variablelist>
+      <varlistentry>
+        <term>Thoroughly test and audit your &sudo; configurations</term>
+        <listitem>
+          <para>
+            To build a truly efficient and secure &sudo; configuration framework, 
+            establish a routine of regular testing and auditing. Make sure that
+            possible loopholes are found and dealt with. Do not let convenience 
+            trump security.
+          </para>
+        </listitem>
+      </varlistentry>
       <varlistentry>
         <term>Keep custom &sudo; configurations in separate files</term>
         <listitem>

--- a/references/sudo-best-practices.xml
+++ b/references/sudo-best-practices.xml
@@ -33,7 +33,7 @@
           <para>
             To build a truly efficient and secure &sudo; configuration framework, 
             establish a routine of regular testing and auditing. Make sure to 
-            identiry possible loopholes and deal with them. Do not let convenience 
+            identify possible loopholes and deal with them. Do not let convenience 
             trump security.
           </para>
         </listitem>

--- a/references/sudo-edit-configuration.xml
+++ b/references/sudo-edit-configuration.xml
@@ -124,6 +124,8 @@
       </varlistentry>
     </variablelist>
   </section>
+
+<!-- this moves to troubleshooting! -->
   <section xml:id="sudo-edit-configuration-debug">
     <title>Checking &sudo; configurations with <command>visudo</command></title>
     <para>
@@ -136,7 +138,7 @@
     </para>
 <screen>&prompt.sudo;visudo -f /etc/sudoers.d/01_test
 [sudo] password for root:
-visudo: /etc/sudoers.d/01_test:1:17: unknown defaults entry "insult"<co xml:id="co-error"/>
+visudo: /etc/sudoers.d/01_test:1:17: unknown defaults entry "mails_always"<co xml:id="co-error"/>
 What now?
 Options are:
   (e)dit sudoers file again<co xml:id="co-edit"/>

--- a/references/sudo-user-authorization.xml
+++ b/references/sudo-user-authorization.xml
@@ -171,7 +171,7 @@ User_List Host_List = [(User_List)] [NOPASSWD:|PASSWD:] Cmnd_List
           <term><literal>Host_List</literal></term>
           <listitem>
             <para>
-              One or several identifiers (separated by comma): either a (fully
+              One or several identifiers (separated by commas): either a (fully
               qualified) host name or an IP address. Negation can be specified
               with the <literal>!</literal> prefix. <literal>ALL</literal> is a
               common choice for <literal>Host_List</literal>.

--- a/references/sudo-user-authorization.xml
+++ b/references/sudo-user-authorization.xml
@@ -198,7 +198,7 @@ User_List Host_List = [(User_List)] [NOPASSWD:|PASSWD:] Cmnd_List
           <term><literal>Cmnd_List</literal></term>
           <listitem>
             <para>
-              One or several specifiers (separated by comma): a path to an
+              One or several specifiers (separated by commas): a path to an
               executable, followed by an optional allowed argument.
             </para>
 <screen>

--- a/references/sudo-user-authorization.xml
+++ b/references/sudo-user-authorization.xml
@@ -160,7 +160,7 @@ User_List Host_List = [(User_List)] [NOPASSWD:|PASSWD:] Cmnd_List
           <term><literal>User_List</literal></term>
           <listitem>
             <para>
-              One or several (separated by comma) identifiers: either a user
+              One or several identifiers (separated by comma): either a user
               name, a group in the format <literal>%GROUPNAME</literal>, or a
               user ID in the format <literal>#UID</literal>. Negation can be
               specified with the <literal>!</literal> prefix.
@@ -171,7 +171,7 @@ User_List Host_List = [(User_List)] [NOPASSWD:|PASSWD:] Cmnd_List
           <term><literal>Host_List</literal></term>
           <listitem>
             <para>
-              One or several (separated by comma) identifiers: either a (fully
+              One or several identifiers (separated by comma): either a (fully
               qualified) host name or an IP address. Negation can be specified
               with the <literal>!</literal> prefix. <literal>ALL</literal> is a
               common choice for <literal>Host_List</literal>.
@@ -198,7 +198,7 @@ User_List Host_List = [(User_List)] [NOPASSWD:|PASSWD:] Cmnd_List
           <term><literal>Cmnd_List</literal></term>
           <listitem>
             <para>
-              One or several (separated by comma) specifiers: a path to an
+              One or several specifiers (separated by comma): a path to an
               executable, followed by an optional allowed argument.
             </para>
 <screen>

--- a/references/sudo-user-authorization.xml
+++ b/references/sudo-user-authorization.xml
@@ -160,7 +160,7 @@ User_List Host_List = [(User_List)] [NOPASSWD:|PASSWD:] Cmnd_List
           <term><literal>User_List</literal></term>
           <listitem>
             <para>
-              One or several identifiers (separated by comma): either a user
+              One or several identifiers (separated by commas): either a user
               name, a group in the format <literal>%GROUPNAME</literal>, or a
               user ID in the format <literal>#UID</literal>. Negation can be
               specified with the <literal>!</literal> prefix.

--- a/references/sudo-user-authorization.xml
+++ b/references/sudo-user-authorization.xml
@@ -23,7 +23,7 @@
     whether you see much changes in this module-->
       <para>
         This section provides a basic &sudo;  configuration reference that helps
-        you understand and maintain both default and custon &sudo; configurations.
+        you understand and maintain both default and custom &sudo; configurations.
       </para>
     </abstract>
   </info>

--- a/references/sudo-user-authorization.xml
+++ b/references/sudo-user-authorization.xml
@@ -16,20 +16,19 @@
  xmlns:xlink="http://www.w3.org/1999/xlink"
  xmlns:trans="http://docbook.org/ns/transclusion">
   <info>
-    <title>&sudo; configuration basics</title>
+    <title>&sudo; configuration reference</title>
     <meta name="maintainer" content="jana.jaeger@suse.com" its:translate="no"/>
     <abstract>
      <!--Remove later: Please do an editorial and structural review of this module, irrespective of
     whether you see much changes in this module-->
       <para>
-        Learn about the basic <filename>sudoers</filename> configuration
-        settings before you start editing or creating your own &sudo;
-        configuration files.
+        This section provides a basic &sudo;  configuration reference that helps
+        you understand and maintain both default and custon &sudo; configurations.
       </para>
     </abstract>
   </info>
   <section xml:id="sudo-user-authorization-syntax">
-    <title>Basic <filename>sudoers</filename> configuration syntax</title>
+    <title><filename>sudoers</filename> configuration syntax</title>
     <para>
     The <filename>sudoers</filename> configuration files contain two types of
     options: strings and flags. While strings can contain any value, flags can

--- a/tasks/sudo-change-pw-timeout.xml
+++ b/tasks/sudo-change-pw-timeout.xml
@@ -59,10 +59,11 @@
         After successful authentication with the &rootuser; password, the file
         is opened.
       </para>
+      <!--
       <para>
         For more information on how to edit the &sudo; configuration file,
         refer to <xref linkend="sudo-edit-configuration"></xref>.
-      </para>
+      </para> -->
     </step>
     <step>
       <para>

--- a/tasks/sudo-change-pw-timeout.xml
+++ b/tasks/sudo-change-pw-timeout.xml
@@ -51,19 +51,14 @@
     <title>Changing the time-out for &sudo; password prompts</title>
     <step>
       <para>
-        Create a new &sudo; configuration file for the timestamp configuration
-        with:
+        As system administrator, create a new &sudo; configuration file for the 
+        timestamp configuration with:
       </para>
-<screen>sudo visudo --f=/etc/sudoers.d/timestamp_timeout</screen>
+<screen>&prompt.root;<command>visudo --f=/etc/sudoers.d/timestamp_timeout</command></screen>
       <para>
         After successful authentication with the &rootuser; password, the file
         is opened.
       </para>
-      <!--
-      <para>
-        For more information on how to edit the &sudo; configuration file,
-        refer to <xref linkend="sudo-edit-configuration"></xref>.
-      </para> -->
     </step>
     <step>
       <para>

--- a/tasks/sudo-change-pw-timeout.xml
+++ b/tasks/sudo-change-pw-timeout.xml
@@ -37,16 +37,16 @@
     &rootuser; privileges, make the following changes to your &sudo;
     configuration file.
   </para>
-  <note>
+  <warning>
     <title>
       Do not grant unlimited passwordless access to &rootuser; privileges
     </title>
     <para>
-      For security reasons you should not give unlimited access to &rootuser;
+      For security reasons, do not give unlimited access to &rootuser;
       privileges. Instead, set a reasonable time-out to prevent misuse of the
       &rootuser; account by any intruder.
     </para>
-  </note>
+  </warning>
   <procedure>
     <title>Changing the time-out for &sudo; password prompts</title>
     <step>

--- a/tasks/sudo-creating-custom-configuration.xml
+++ b/tasks/sudo-creating-custom-configuration.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+[
+  <!ENTITY % entities SYSTEM "../common/generic-entities.ent">
+    %entities;
+]>
+<!-- refers to legacy doc: <add github link to legacy doc piece, if applicable> -->
+<!-- point back to this document with a similar comment added to your legacy doc piece -->
+<!-- refer to README.md for file and id naming conventions -->
+<!-- metadata is dealt with on the assembly level -->
+<topic xml:id="task-example"
+ role="task" xml:lang="en"
+ xmlns="http://docbook.org/ns/docbook" version="5.2"
+ xmlns:its="http://www.w3.org/2005/11/its"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink"
+ xmlns:trans="http://docbook.org/ns/transclusion">
+  <info>
+    <title>Executing task X (with tool Y)</title><!-- can be changed via merge
+in the assembly -->
+    <!-- add author's e-mail -->
+    <meta name="maintainer" content="" its:translate="no"/>
+    <abstract><!-- can be changed via merge in the assembly -->
+      <para>
+       Introductory text
+      </para>
+    </abstract>
+  </info>
+  <section xml:id="task-example-introduction">
+    <title>Introduction</title>
+    <para>
+      A paragraph of text.
+    </para>
+  </section>
+  <section xml:id="task-example-requirements">
+    <title>Requirements</title>
+    <itemizedlist>
+      <listitem>
+        <para>
+          An
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Unordered
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          List
+        </para>
+      </listitem>
+    </itemizedlist>
+    <para>
+      A paragraph of text.
+    </para>
+  </section>
+  <section xml:id="task-example-executing">
+    <title>Executing the task</title>
+    <para>
+      A paragraph of text.
+    </para>
+    <procedure>
+      <para>
+        A short introduction to the procedure.
+      </para>
+      <step>
+        <para>
+          A step.
+        </para>
+      </step>
+      <step>
+        <para>
+          A second step.
+        </para>
+      </step>
+      <step>
+        <para>
+          A third step.
+        </para>
+      </step>
+    </procedure>
+  </section>
+  <section xml:id="task-example-summary">
+    <title>Summary</title>
+    <para>
+      A paragraph of text, summing up the result of the task.
+    </para>
+  </section>
+  <section xml:id="task-example-troubleshooting">
+    <title>Troubleshooting</title>
+    <para>
+      Add some troubleshooting information, if applicable.
+    </para>
+  </section>
+</topic>

--- a/tasks/sudo-creating-custom-configuration.xml
+++ b/tasks/sudo-creating-custom-configuration.xml
@@ -8,7 +8,7 @@
 <!-- point back to this document with a similar comment added to your legacy doc piece -->
 <!-- refer to README.md for file and id naming conventions -->
 <!-- metadata is dealt with on the assembly level -->
-<topic xml:id="task-example"
+<topic xml:id="sudo-creating-custom-configuration"
  role="task" xml:lang="en"
  xmlns="http://docbook.org/ns/docbook" version="5.2"
  xmlns:its="http://www.w3.org/2005/11/its"
@@ -16,54 +16,85 @@
  xmlns:xlink="http://www.w3.org/1999/xlink"
  xmlns:trans="http://docbook.org/ns/transclusion">
   <info>
-    <title>Executing task X (with tool Y)</title><!-- can be changed via merge
+    <title>Creating a custom &sudo; configuration file</title><!-- can be changed via merge
 in the assembly -->
     <!-- add author's e-mail -->
-    <meta name="maintainer" content="" its:translate="no"/>
+    <meta name="maintainer" content="jana.jaeger@suse.com" its:translate="no"/>
     <abstract><!-- can be changed via merge in the assembly -->
       <para>
-       Introductory text
+       Learn how to build a simple custom &sudo; configuration and expand it 
+       step-by-step. You will be creating a custom configuration that allows a 
+       certain user to run the <command>useradd</command>, <command>usermod</command> 
+       and <command>userdel</command> command with &sudo; and their own password
+       instead of the &rootuser;'s password. Learn how to create groups and how 
+       to use aliases to keep your custom configuration lean and efficient.
       </para>
     </abstract>
   </info>
-  <section xml:id="task-example-introduction">
-    <title>Introduction</title>
+  <section xml:id="sudo-creating-custom-configuration-bp">
+    <title>&sudo; configuration best practices</title>
     <para>
-      A paragraph of text.
+      Before your start, here are a few ground rules for maintaining &sudo; 
+      configurations:
     </para>
+    <variablelist>
+      <varlistentry>
+        <term>Always use <command>visudo</command> to edit &sudo; configuration files</term>
+        <listitem>
+          <para>
+            Any changes to the &sudo; configuration should be done using the 
+            <command>visudo</command>. <command>visudo</command> is a tailor-made tool 
+            that allows you to edit the &sudo; configuration files and that runs basic 
+            synthax checks making sure that the configuration remains intact and 
+            functional. A faulty &sudo; configuration can result in a user being 
+            locked out of their own system.
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>Always create custom configurations under <filename>/etc/sudoers.d/</filename></term>
+        <listitem>
+          <para>
+            Custom configurations must reside under the 
+            <filename>/etc/sudoers.de</filename> to be pulled in by &sudo;. 
+            Settings in the custom configuration files take precedence over the 
+            ones in the default confiugation in <filename>/etc/sudoers</filename>. 
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>Always mind the order in which configurations are read</term>
+        <listitem>
+          <para>
+            To make sure the custom configurations are read in the correct order, prefix them with numbers.
+            Use leading zeroes to establish the order in which the files are read. For example,
+            <filename>01_myfirstconfig</filename> is parsed before
+            <filename>10_myotherconfig</filename>. If a directive has been set 
+            in one file that is read before another file that contains 
+            conflicting information, the last-read directive is applied. 
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>Always use descriptive file names</term>
+        <listitem>
+          <para>
+            Use file names that hint at what the configuration file does. This 
+            helps you keep track of what your &sudo; setup is supposed to do.
+          </para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
   </section>
-  <section xml:id="task-example-requirements">
-    <title>Requirements</title>
-    <itemizedlist>
-      <listitem>
-        <para>
-          An
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          Unordered
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          List
-        </para>
-      </listitem>
-    </itemizedlist>
+
+  <section xml:id="sudo-creating-custom-config-single-user">
+    <title>Create a user-specific configuration file</title>
     <para>
-      A paragraph of text.
-    </para>
-  </section>
-  <section xml:id="task-example-executing">
-    <title>Executing the task</title>
-    <para>
-      A paragraph of text.
+      Create a &sudo; configuration file that allows &exampleuser; to use the 
+      <command>useradd</command> command with their own password instead of the 
+      &rootuser; password. 
     </para>
     <procedure>
-      <para>
-        A short introduction to the procedure.
-      </para>
       <step>
         <para>
           A step.
@@ -80,17 +111,5 @@ in the assembly -->
         </para>
       </step>
     </procedure>
-  </section>
-  <section xml:id="task-example-summary">
-    <title>Summary</title>
-    <para>
-      A paragraph of text, summing up the result of the task.
-    </para>
-  </section>
-  <section xml:id="task-example-troubleshooting">
-    <title>Troubleshooting</title>
-    <para>
-      Add some troubleshooting information, if applicable.
-    </para>
   </section>
 </topic>

--- a/tasks/sudo-creating-custom-configuration.xml
+++ b/tasks/sudo-creating-custom-configuration.xml
@@ -16,7 +16,7 @@
  xmlns:xlink="http://www.w3.org/1999/xlink"
  xmlns:trans="http://docbook.org/ns/transclusion">
   <info>
-    <title>Creating a custom &sudo; configuration file</title><!-- can be changed via merge
+    <title>Creating custom &sudo; configurations</title><!-- can be changed via merge
 in the assembly -->
     <!-- add author's e-mail -->
     <meta name="maintainer" content="jana.jaeger@suse.com" its:translate="no"/>
@@ -102,7 +102,7 @@ in the assembly -->
           Use both numbering and a descriptive name:
         </para>
         <screen>
-&sudoprompt; visudo -f /etc/sudoers.d/01_usermanagement
+&prompt.sudo; visudo -f /etc/sudoers.d/01_usermanagement
 </screen>
       </step>
       <step>
@@ -121,19 +121,110 @@ tux<co xml:id="who"/> ALL<co xml:id="where"/> = /usr/sbin/useradd<co xml:id="wha
           <callout arearefs="who">
             <para>
               Specify the user or group. Users by name or <literal>#UID</literal> 
-              groups by <literal>%GROUPNAME</literal>. If you have several items here, separate them with commas.
-              To negate entries, use <literal>!</literal>. 
+              groups by <literal>%GROUPNAME</literal>. If you have several items 
+              here, separate them with commas. To negate entries, use 
+              <literal>!</literal>.
             </para>
           </callout>
           <callout arearefs="where">
             <para>
-              Specify one or several (separated by commas) hosts.
+              Specify one or several (separated by commas) hosts. Use 
+              (fully qualified) host names or IP addresses. Use 
+              <literal>ALL</literal> to enforce this setting globally 
+              across all hosts and use <literal>!</literal> for negations.
             </para>
           </callout>
           <callout arearefs="what">
-            <para></para>
+            <para>
+              Specify one or several executables (separated by commas). When 
+              specifying them, make sure to mind the following rules:
+            </para>
+            <variablelist>
+              <varlistentry>
+                <term><command>/usr/sbin/useradd</command></term>
+                <listitem>
+                  <para>
+                    Without any additional options added, this allows the 
+                    execution of every possible <command>useradd</command> command.
+                  </para>
+                </listitem>
+              </varlistentry>
+              <varlistentry>
+                <term><command>/usr/sbin/useradd -c</command></term>
+                <listitem>
+                  <para>
+                    If you explicitely specify an option, then that option is 
+                    the only one that is allowed. Nothing else would be available
+                    to the user you specified above.
+                  </para>
+                </listitem>
+              </varlistentry>
+                            <varlistentry>
+                <term><command>/usr/sbin/useradd ""</command></term>
+                <listitem>
+                  <para>
+                    This would just let the user invoke a mere 
+                    <command>useradd</command> without any option at all. 
+                  </para>
+                </listitem>
+              </varlistentry>
+            </variablelist>
+            <para>
+              In the example above, you would want to either allow all
+              options and subcommands or limit them to a few for security 
+              reasons, but forbidding a user to specify any option at all is
+              pointless in our context.
+            </para>
           </callout>
         </calloutlist>
+      </step>
+      <step>
+        <para>
+          To enable the user to be able to use their own password instead of the 
+          &rootuser; password, open <filename>/etc/sudoers</filename> with 
+          <command>visudo</command> and comment or remove the following lines 
+          and save the configuration:
+        </para>
+        <screen>Defaults targetpw<co xml:id="targetpw"/>   # ask for the password of the target user i.e. root
+ALL   ALL=(ALL) ALL<co xml:id="ALL"/>   # WARNING! Only use this together with 'Defaults targetpw'!
+</screen>
+        <calloutlist>
+          <callout arearefs="targetpw">
+            <para>
+              When active, this flag requires the user to enter the password of 
+              the target user, i.e. &rootuser;. This flag is enabled by default on 
+              any &product; system. When disabled, no password is required.
+            </para>
+          </callout>
+          <callout arearefs="ALL">
+            <para>
+              This rule allows all users on all hosts to run all executables as 
+              any user. Use this rule only together with 
+              <literal>Defaults targetpw</literal>. Disabling this rule lets 
+              &sudo; check for user-specific rules with user-specific permissions.
+            </para>
+          </callout>
+        </calloutlist>
+      </step>
+      <step>
+        <para>Check whether there are any errors with your &sudo; configuration:
+        </para>
+        <screen>&prompt.sudo;visudo -c
+/etc/sudoers: parsed OK
+/etc/sudoers.d/01_usermanagement: parsed OK
+</screen>
+        <para>
+          This tells you that all of your configuration files are syntactically
+          correct and gives you the order in which the configurations
+          are parsed. This information is needed in case you notice unexpected
+          behavior of &sudo; which can simply be caused by directives being
+          applied in the wrong order or overriding each other. If the configuration
+          contains an error, <command>visudo</command> reports the file
+          name, line number and error description of the affected file.
+        </para>
+      </step>
+      <step>
+        <para></para>
       </step>
     </procedure>
   </section>

--- a/tasks/sudo-creating-custom-configuration.xml
+++ b/tasks/sudo-creating-custom-configuration.xml
@@ -193,7 +193,7 @@ ALL   ALL=(ALL) ALL<co xml:id="ALL"/>   # WARNING! Only use this together with '
             <para>
               When active, this flag requires the user to enter the password of 
               the target user, i.e. &rootuser;. This flag is enabled by default on 
-              any &product; system. When disabled, no password is required.
+              any &productname; system. When disabled, no password is required.
             </para>
           </callout>
           <callout arearefs="ALL">
@@ -212,6 +212,7 @@ ALL   ALL=(ALL) ALL<co xml:id="ALL"/>   # WARNING! Only use this together with '
         <screen>&prompt.sudo;visudo -c
 /etc/sudoers: parsed OK
 /etc/sudoers.d/01_usermanagement: parsed OK
+...
 </screen>
         <para>
           This tells you that all of your configuration files are syntactically

--- a/tasks/sudo-creating-custom-configuration.xml
+++ b/tasks/sudo-creating-custom-configuration.xml
@@ -277,10 +277,11 @@ ALL   ALL=(ALL) ALL<co xml:id="co-ALL"/>   # WARNING! Only use this together wit
     <para>
       Using aliases and groups instead of lists is a much better way to address 
       changes in your setup. Should a user leave, just remove them from the 
-      global user alias declaration in <filename>/etc/sudoers</filename> instead 
-      of scouring all the separate custom configuration files. The same 
-      procedure applies for any other type of alias (host aliases, command 
-      aliases and run as aliases).
+      global <literal>User_Alias</literal> declaration in 
+      <filename>/etc/sudoers</filename> instead of scouring all the separate 
+      custom configuration files. The same procedure applies for any other 
+      type of alias (<literal>Host_Alias</literal>, <literal>Cmnd_Alias</literal> 
+      and <literal>Runas_Alias</literal>).
     </para>
     <example xml:id="ex-sudo-custom-config-alias">
       <title>Simplify configurations by applying aliases</title>

--- a/tasks/sudo-creating-custom-configuration.xml
+++ b/tasks/sudo-creating-custom-configuration.xml
@@ -23,8 +23,8 @@ in the assembly -->
     <abstract><!-- can be changed via merge in the assembly -->
       <para>
        Learn how to build a simple example custom &sudo; configuration and 
-       expand it step-by-step. Learn how to create groups and how 
-       to use aliases to keep your custom configuration lean and efficient.
+       expand it step-by-step. Create groups and how use aliases to keep your 
+       custom configuration lean and efficient.
       </para>
     </abstract>
   </info>
@@ -108,7 +108,7 @@ in the assembly -->
           <command>visudo</command>. Use both numbering and a descriptive name:
         </para>
         <screen>
-&prompt.root;visudo -f /etc/sudoers.d/01_usermanagement
+&prompt.root;<command>visudo -f /etc/sudoers.d/01_usermanagement</command>
 </screen>
       </step>
       <step>
@@ -126,10 +126,10 @@ tux<co xml:id="who"/> ALL<co xml:id="where"/> = /usr/sbin/useradd<co xml:id="wha
         <calloutlist>
           <callout arearefs="who">
             <para>
-              Specify the user or group. Users by name or <literal>#UID</literal> 
-              groups by <literal>%GROUPNAME</literal>. If you have several items 
-              here, separate them with commas. To negate entries, use 
-              <literal>!</literal>.
+              Specify the user or group. List users by name or 
+              <literal>#UID</literal>, groups by <literal>%GROUPNAME</literal>. 
+              If you have several items here, separate them with commas. To 
+              negate entries, use <literal>!</literal>.
             </para>
           </callout>
           <callout arearefs="where">
@@ -178,8 +178,8 @@ tux<co xml:id="who"/> ALL<co xml:id="where"/> = /usr/sbin/useradd<co xml:id="wha
             <para>
               In the example above, you would want to either allow all
               options and subcommands or limit them to a few for security 
-              reasons, but forbidding a user to specify any option at all is
-              pointless in our context.
+              reasons, but forbidding a user to specify any option at all 
+              would be pointless in this context.
             </para>
           </callout>
         </calloutlist>
@@ -188,7 +188,7 @@ tux<co xml:id="who"/> ALL<co xml:id="where"/> = /usr/sbin/useradd<co xml:id="wha
           password, add the <literal>NOPASSWD:</literal> in front ot the 
           executable's path. By default, &sudo; requires the user to enter a 
           password, so that you do not have to specify the <literal>PASSWD:</literal>
-          option explicitely. Adding it is just required if you specify a list 
+          option explicitely. It is only required, if you specify a list 
           of executables that should behave differently:
         </para>
         <screen>
@@ -197,8 +197,8 @@ tux<co xml:id="who"/> ALL<co xml:id="where"/> = /usr/sbin/useradd<co xml:id="wha
       </step>
       <step>
         <para>
-          To enable the user to be able to use their own password instead of the 
-          &rootuser; password, open <filename>/etc/sudoers</filename> with 
+          To let the user use their own password instead of the &rootuser; 
+          password, open <filename>/etc/sudoers</filename> with 
           <command>visudo</command> and comment or remove the following lines 
           and save the configuration:
         </para>
@@ -226,13 +226,15 @@ ALL   ALL=(ALL) ALL<co xml:id="ALL"/>   # WARNING! Only use this together with '
       <step>
        <para>
         Save the configuration, leave the editor and open a second shell to test 
-        whether &sudo; honors your new configuration.
+        whether &sudo; honors your new configuration. If you have accidentally 
+        introduced a syntax error, <command>visudo</command> will report it as 
+        soon as you try to save and exit the editor.
        </para>
       </step>
       <step>
-        <para>Check whether there are any errors with your &sudo; configuration:
+        <para>To check for any errors with your overall &sudo; configuration:
         </para>
-        <screen>&prompt.root;visudo -c
+        <screen>&prompt.root;<command>visudo -c</command>
 /etc/sudoers: parsed OK
 /etc/sudoers.d/01_usermanagement: parsed OK
 ...
@@ -261,10 +263,10 @@ ALL   ALL=(ALL) ALL<co xml:id="ALL"/>   # WARNING! Only use this together with '
     <procedure>
       <step>
         <para>
-          To modify the example configuration, open it with 
+          To modify the example configuration, open it as system administrator with 
           <command>visudo</command>:
         </para>
-        <screen>&prompt.root;visudo /etc/sudoers.d/01_usermanagement
+        <screen>&prompt.root;<command>visudo /etc/sudoers.d/01_usermanagement</command>
 </screen>
       </step>
       <step>
@@ -290,18 +292,12 @@ ALL   ALL=(ALL) ALL<co xml:id="ALL"/>   # WARNING! Only use this together with '
         </para>
       </step>
       <step>
-        <para>
-          Save the configuration, leave the editor and open a second shell to test 
-        whether &sudo; honors your new configuration.
-        </para>
-      </step>
-      <step>
-        <para>Check whether there are any errors with your &sudo; configuration:
-        </para>
-        <screen>&prompt.root;visudo -c
-/etc/sudoers: parsed OK
-/etc/sudoers.d/01_usermanagement: parsed OK
-...</screen>
+       <para>
+        Save the configuration, leave the editor and open a second shell to test 
+        whether &sudo; honors your new configuration. If you have accidentally 
+        introduced a syntax error, <command>visudo</command> will report it as 
+        soon as you try to save and exit the editor.
+       </para>
       </step>
     </procedure>
   </section>
@@ -310,45 +306,59 @@ ALL   ALL=(ALL) ALL<co xml:id="ALL"/>   # WARNING! Only use this together with '
     <para>
       Use aliases to simplify your custom configuration from 
       <xref linkend="sudo-creating-custom-config-group"/> even further. 
-      Grouping items helps to a certain extent, but using aliases for users, 
+      Grouping items helps to a certain extent, but using global aliases for users, 
       commands and hosts is the most efficient way to keep a clean and 
       lean &sudo; configuration.
+    </para>
+    <para>
+      Using aliases and groups instead of lists is a much better way to address 
+      changes in your setup. Should a user leave, just remove them from the 
+      global user alias declaration in <filename>/etc/sudoers</filename> instead 
+      of scouring all the separate custom configuration files. The same 
+      procedure applies for any other type of alias (host aliases, command 
+      aliases and run as aliases).
     </para>
 
     <procedure>
       <step>
         <para>
-          To modify the example configuration, open it with 
-          <command>visudo</command>:
+          To add user and command aliases to be used in the example 
+          configuration file, run <command>visudo</command> as system 
+          administrator to edit the global &sudo; configuration file 
+          (<filename>/etc/sudoers</filename>).
         </para>
-        <screen>&prompt.root;visudo /etc/sudoers.d/01_usermanagement
-</screen>
-        <para>
-          The current example from <xref linkend="sudo-creating-custom-config-group"/> 
-          looks like this:
-        </para>
-        <screen>&exampleuser_plain;, &exampleuserII_plain; ALL = /usr/sbin/useradd, /usr/sbin/usermod, /usr/sbin/userdel
-</screen>
       </step>
-      <step>        
+      <step>
         <para>
-          To create an alias for a group of users, add the following line above 
-          the rule itself:
+          In the <literal>User_Alias</literal> section, add the following 
+          line to create the <literal>TEAMLEADERS</literal> alias:
         </para>
-        <screen>User_Alias TEAMLEADERS = &exampleuser_plain;, &exampleuserII_plain;
+        <screen>User_Alias    TEAMLEADERS = &exampleuser_plain;, &exampleuserII_plain;
 </screen>
       </step>
       <step>
         <para>
-          To add an alias for a group of commands, add the following line above 
-          the rule itself:
+          In the <literal>Cmnd_Alias</literal> section, add the following 
+          line to create the <literal>USERMANAGEMENT</literal> alias:
         </para>
-        <screen>Cmnd_Alias USERMANAGEMENT = /usr/sbin/useradd, /usr/sbin/usermod, /usr/sbin/userdel
+        <screen>Cmnd_Alias    USERMANAGEMENT = /usr/sbin/useradd, /usr/sbin/usermod, /usr/sbin/userdel
 </screen>
       </step>
       <step>
         <para>
-          Adjust the rule to use the aliases:
+          Save your changes and exit <command>visudo</command>.
+        </para>
+      </step>
+      <step>
+        <para>
+          As system administrator, start <command>visudo</command> to edit the 
+          example configuration file:</para>
+        <screen>&prompt.root;<command>visudo -f /etc/sudoers.d/01_usermanagement</command>
+</screen>
+      </step>
+      <step>
+        <para>
+           Adjust the rule to use the aliases:
         </para>
         <screen>TEAMLEADERS ALL = USERMANAGEMENT
 </screen>
@@ -356,16 +366,10 @@ ALL   ALL=(ALL) ALL<co xml:id="ALL"/>   # WARNING! Only use this together with '
       <step>
         <para>
           Save the configuration, leave the editor and open a second shell to test 
-          whether &sudo; honors your new configuration.
+          whether &sudo; honors your new configuration. If you have accidentally 
+          introduced a syntax error, <command>visudo</command> will report it as 
+          soon as you try to save and exit the editor.
         </para>
-      </step>
-      <step>
-        <para>Check whether there are any errors with your &sudo; configuration:
-        </para>
-        <screen>&prompt.root;visudo -c
-/etc/sudoers: parsed OK
-/etc/sudoers.d/01_usermanagement: parsed OK
-...</screen>
       </step>
     </procedure>
   </section>

--- a/tasks/sudo-creating-custom-configuration.xml
+++ b/tasks/sudo-creating-custom-configuration.xml
@@ -31,9 +31,9 @@ in the assembly -->
   <warning>
     <title>Example configurations are for demonstration purposes only</title>
     <para>
-      Note that the example rules outlined below are purely for 
-      demonstration purposes. Use them to understand the general syntax of 
-      &sudo; configuration files. Do not use them in real-world setups, because they 
+      The example rules outlined below are purely for demonstration purposes. 
+      Use them to understand the general syntax of &sudo; configuration files. 
+      Do not use them in real-world setups, because they 
       do not reflect the complexity of these environments.
     </para>
   </warning>
@@ -49,11 +49,11 @@ in the assembly -->
         <listitem>
           <para>
             Any changes to the &sudo; configuration should be done using the 
-            <command>visudo</command>. <command>visudo</command> is a tailor-made tool 
-            that allows you to edit the &sudo; configuration files and that runs basic 
-            synthax checks making sure that the configuration remains intact and 
-            functional. A faulty &sudo; configuration can result in a user being 
-            locked out of their own system.
+            <command>visudo</command> command. <command>visudo</command> is a 
+            tailor-made tool that allows you to edit the &sudo; configuration 
+            files and that runs basic synthax checks making sure that the 
+            configuration remains intact and functional. A faulty &sudo; 
+            configuration can result in a user being locked out of their own system.
           </para>
         </listitem>
       </varlistentry>
@@ -62,7 +62,7 @@ in the assembly -->
         <listitem>
           <para>
             Custom configurations must reside under the 
-            <filename>/etc/sudoers.de</filename> to be pulled in by &sudo;. 
+            <filename>/etc/sudoers.d</filename> to be pulled in by &sudo;. 
             Settings in the custom configuration files take precedence over the 
             ones in the default configuration in <filename>/etc/sudoers</filename>. 
           </para>
@@ -100,213 +100,177 @@ in the assembly -->
       to use the <command>useradd</command> command with their own password 
       instead of the &rootuser; password. 
     </para>
-    <procedure>
-      <step>
-        <para>
-          As system administrator (&rootuser;), create a custom configuration 
-          file that holds the new user-specific directives by starting 
-          <command>visudo</command>. Use both numbering and a descriptive name:
-        </para>
-        <screen>
+    <example xml:id="ex-sudo-custom-config-user">
+      <title>Create a user-specific configuration file</title>
+      <procedure>
+        <step>
+          <para>
+            As system administrator (&rootuser;), create a custom configuration 
+            file that holds the new user-specific directives by starting 
+            <command>visudo</command>. Use both numbering and a descriptive name:
+          </para>
+          <screen>
 &prompt.root;<command>visudo -f /etc/sudoers.d/01_usermanagement</command>
 </screen>
-      </step>
-      <step>
-        <para>
-          Create a rule that allows &exampleuser; to execute the 
-          <command>/usr/sbin/useradd</command> binary in the entire environment 
-          that this &sudo; configuration is applied to:
-        </para>
-        <screen>
-tux<co xml:id="who"/> ALL<co xml:id="where"/> = /usr/sbin/useradd<co xml:id="what"/>
+        </step>
+        <step>
+          <para>
+            Create a rule that allows &exampleuser; to execute the 
+            <command>/usr/sbin/useradd</command> binary in the entire environment 
+            that this &sudo; configuration is applied to:
+          </para>
+          <screen>
+tux<co xml:id="co-who"/> ALL<co xml:id="co-where"/> = /usr/sbin/useradd<co xml:id="co-what"/>
 </screen>
-        <para>
-
-        </para>
-        <calloutlist>
-          <callout arearefs="who">
-            <para>
-              Specify the user or group. List users by name or 
-              <literal>#UID</literal>, groups by <literal>%GROUPNAME</literal>. 
-              If you have several items here, separate them with commas. To 
-              negate entries, use <literal>!</literal>.
-            </para>
-          </callout>
-          <callout arearefs="where">
-            <para>
-              Specify one or several (separated by commas) hosts. Use 
-              (fully qualified) host names or IP addresses. Use 
-              <literal>ALL</literal> to enforce this setting globally 
-              across all hosts. Use <literal>!</literal> for negations.
-            </para>
-          </callout>
-          <callout arearefs="what">
-            <para>
-              Specify one or several executables (separated by commas). When 
-              specifying them, make sure to mind the following rules:
-            </para>
-            <variablelist>
-              <varlistentry>
-                <term><command>/usr/sbin/useradd</command></term>
-                <listitem>
-                  <para>
-                    Without any additional options added, this allows the 
-                    execution of every possible <command>useradd</command> command.
-                  </para>
-                </listitem>
-              </varlistentry>
-              <varlistentry>
-                <term><command>/usr/sbin/useradd -c</command></term>
-                <listitem>
-                  <para>
-                    If you explicitely specify an option, then that option is 
-                    the only one that is allowed. Nothing else would be available
-                    to the user you specified above.
-                  </para>
-                </listitem>
-              </varlistentry>
-                            <varlistentry>
-                <term><command>/usr/sbin/useradd ""</command></term>
-                <listitem>
-                  <para>
-                    This would just let the user invoke a mere 
-                    <command>useradd</command> without any option at all. 
-                  </para>
-                </listitem>
-              </varlistentry>
-            </variablelist>
-            <para>
-              In the example above, you would want to either allow all
-              options and subcommands or limit them to a few for security 
-              reasons, but forbidding a user to specify any option at all 
-              would be pointless in this context.
-            </para>
-          </callout>
-        </calloutlist>
-        <para>
-          To enable the specified user to use the command without entering any 
-          password at all, add the <literal>NOPASSWD:</literal> in front ot the 
-          executable's path. By default, &sudo; requires the user to enter a 
-          password, so that you do not have to specify the <literal>PASSWD:</literal>
-          option explicitely. It is only required, if you specify a list 
-          of executables that should behave differently:
-        </para>
-        <screen>
-&exampleuser_plain; ALL = PASSWD: /usr/sbin/useradd, NOPASSWD: /usr/bin/zypper
+          <calloutlist>
+            <callout arearefs="co-who">
+              <para>
+                Specify the user or group. List users by name or 
+                <literal>#UID</literal>, groups by <literal>%GROUPNAME</literal>. 
+                If you have several items here, separate them with commas. To 
+                negate entries, use <literal>!</literal>.
+              </para>
+            </callout>
+            <callout arearefs="co-where">
+              <para>
+                Specify one or several (separated by commas) hosts. Use 
+                (fully qualified) host names or IP addresses. Use 
+                <literal>ALL</literal> to enforce this setting globally 
+                across all hosts. Use <literal>!</literal> for negations.
+              </para>
+            </callout>
+            <callout arearefs="co-what">
+              <para>
+                Specify one or several executables (separated by commas). When 
+                specifying them, make sure to mind the following rules:
+              </para>
+              <variablelist>
+                <varlistentry>
+                  <term><command>/usr/sbin/useradd</command></term>
+                  <listitem>
+                    <para>
+                      Without any additional options added, this allows the 
+                      execution of every possible <command>useradd</command> command.
+                    </para>
+                  </listitem>
+                </varlistentry>
+                <varlistentry>
+                  <term><command>/usr/sbin/useradd -c</command></term>
+                  <listitem>
+                    <para>
+                      If you explicitely specify an option, then that option is 
+                      the only one that is allowed. Nothing else would be available
+                      to the user you specified above.
+                    </para>
+                  </listitem>
+                </varlistentry>
+                <varlistentry>
+                  <term><command>/usr/sbin/useradd ""</command></term>
+                  <listitem>
+                    <para>
+                      This would just let the user invoke a mere 
+                      <command>useradd</command> without any option at all. 
+                    </para>
+                  </listitem>
+                </varlistentry>
+              </variablelist>
+              <para>
+                In the example above, you would want to either allow all
+                options and subcommands or limit them to a few for security 
+                reasons, but forbidding a user to specify any option at all 
+                would be pointless in this context.
+              </para>
+            </callout>
+          </calloutlist>
+        </step>
+        <step>
+          <para>
+            To let the user use their own password instead of the &rootuser; 
+            password, open <filename>/etc/sudoers</filename> with 
+            <command>visudo</command> and comment or remove the following lines 
+            and save the configuration:
+          </para>
+          <screen>Defaults targetpw<co xml:id="co-targetpw"/>   # ask for the password of the target user i.e. root
+ALL   ALL=(ALL) ALL<co xml:id="co-ALL"/>   # WARNING! Only use this together with 'Defaults targetpw'!
 </screen>
-      </step>
-      <step>
-        <para>
-          To let the user use their own password instead of the &rootuser; 
-          password, open <filename>/etc/sudoers</filename> with 
-          <command>visudo</command> and comment or remove the following lines 
-          and save the configuration:
-        </para>
-        <screen>Defaults targetpw<co xml:id="targetpw"/>   # ask for the password of the target user i.e. root
-ALL   ALL=(ALL) ALL<co xml:id="ALL"/>   # WARNING! Only use this together with 'Defaults targetpw'!
-</screen>
-        <calloutlist>
-          <callout arearefs="targetpw">
-            <para>
-              When active, this flag requires the user to enter the password of 
-              the target user, i.e. &rootuser;. This flag is enabled by default on 
-              any &productname; system.
-            </para>
-          </callout>
-          <callout arearefs="ALL">
-            <para>
-              This rule allows all users on all hosts to run all executables as 
-              any user. Never use this rule without
-              <literal>Defaults targetpw</literal>. Disabling this rule lets 
-              &sudo; check for user-specific rules with user-specific permissions.
-            </para>
-          </callout>
-        </calloutlist>
-      </step>
-      <step>
-       <para>
-        Save the configuration, leave the editor and open a second shell to test 
-        whether &sudo; honors your new configuration. If you have accidentally 
-        introduced a syntax error, <command>visudo</command> will report it as 
-        soon as you try to save and exit the editor.
-       </para>
-      </step>
-      <step>
-        <para>To check for any errors in your overall &sudo; configuration, run:
-        </para>
-        <screen>&prompt.root;<command>visudo -c</command>
-/etc/sudoers: parsed OK
-/etc/sudoers.d/01_usermanagement: parsed OK
-...
-</screen>
-        <para>
-          This tells you that all of your configuration files are syntactically
-          correct and gives you the order in which the configurations
-          are parsed. This information is needed in case you notice unexpected
-          behavior of &sudo; which can simply be caused by directives being
-          applied in the wrong order or overriding each other. If the configuration
-          contains an error, <command>visudo</command> reports the file
-          name, line number and error description of the affected file.
-        </para>
-      </step>
-    </procedure>
+          <calloutlist>
+            <callout arearefs="co-targetpw">
+              <para>
+                When active, this flag requires the user to enter the password of 
+                the target user, i.e. &rootuser;. This flag is enabled by default on 
+                any &productname; system.
+              </para>
+            </callout>
+            <callout arearefs="co-ALL">
+              <para>
+                This rule allows all users on all hosts to run all executables as 
+                any user. Never use this rule without
+                <literal>Defaults targetpw</literal>. Disabling this rule lets 
+                &sudo; check for user-specific rules with user-specific permissions.
+              </para>
+            </callout>
+          </calloutlist>
+        </step>
+        <step>
+          <para>
+            Save the configuration, leave the editor and open a second shell to test 
+            whether &sudo; honors your new configuration.
+          </para>
+        </step>
+      </procedure>
+    </example>
   </section>
-    <section xml:id="sudo-creating-custom-config-group">
+
+  <section xml:id="sudo-creating-custom-config-group">
     <title>Create custom configurations by grouping items</title>
     <para>
-      Modify the example from <xref linkend="sudo-creating-custom-config-single-user"/> 
+      Modify the configuration from <xref linkend="ex-sudo-custom-config-user"/> 
       so that a group of named users can run the <command>useradd</command> 
       command without the need for the &rootuser; password. Also, add the 
       <command>usermod</command> and <command>userdel</command> to the list of 
       commands available to this group.
     </para>
-    <procedure>
-      <step>
-        <para>
-          To modify the example configuration, open it as system administrator with 
-          <command>visudo</command>:
-        </para>
-        <screen>&prompt.root;<command>visudo /etc/sudoers.d/01_usermanagement</command>
+    <example xml:id="ex-sudo-custom-config-group">
+      <title>Create custom configurations by grouping items</title>
+      <procedure>
+        <step>
+          <para>
+            To modify the example configuration, open it as system administrator with 
+            <command>visudo</command>:
+          </para>
+          <screen>&prompt.root;<command>visudo /etc/sudoers.d/01_usermanagement</command>
 </screen>
-      </step>
-      <step>
-        <para>
-          To add more users to the rule, just use a comma-separated list:
-        </para>
-        <screen>&exampleuser_plain;, &exampleuserII_plain; ALL = /usr/sbin/useradd
+        </step>
+        <step>
+          <para>
+            To add more users to the rule, just use a comma-separated list:
+          </para>
+          <screen>&exampleuser_plain;, &exampleuserII_plain; ALL = /usr/sbin/useradd
 </screen>
-      </step>
-      <step>
-        <para>
-          To allow the listed users to execute a list of commands, specify the 
-          commands as a comma-separated list:
-        </para>
-        <screen>&exampleuser_plain;, &exampleuserII_plain; ALL = /usr/sbin/useradd, /usr/sbin/usermod, /usr/sbin/userdel
+        </step>
+        <step>
+          <para>
+            To allow the listed users to execute a list of commands, specify the 
+            commands as a comma-separated list:
+          </para>
+          <screen>&exampleuser_plain;, &exampleuserII_plain; ALL = /usr/sbin/useradd, /usr/sbin/usermod, /usr/sbin/userdel
 </screen>
-        <para>
-          The <literal>PASSWD:</literal> option is again implied for all the 
-          commands specified on this line. If one or more commands on the same 
-          line should not require a password, then you would have to explicitely 
-          specify the <literal>PASSWD:</literal> and <literal>NOPASSWD:</literal> 
-          with every single one of them.
-        </para>
-      </step>
-      <step>
-       <para>
-        Save the configuration, leave the editor and open a second shell to test 
-        whether &sudo; honors your new configuration. If you have accidentally 
-        introduced a syntax error, <command>visudo</command> will report it as 
-        soon as you try to save and exit the editor.
-       </para>
-      </step>
-    </procedure>
+        </step>
+        <step>
+          <para>
+            Save the configuration, leave the editor and open a second shell to test 
+            whether &sudo; honors your new configuration.
+          </para>
+        </step>
+      </procedure>
+    </example>
   </section>
-    <section xml:id="sudo-creating-custom-config-aliases">
+  <section xml:id="sudo-creating-custom-config-aliases">
     <title>Simplify configurations by applying aliases</title>
     <para>
       Use aliases to simplify your custom configuration from 
-      <xref linkend="sudo-creating-custom-config-group"/> even further. 
-      Grouping items helps to a certain extent, but using global aliases for users, 
+      <xref linkend="ex-sudo-custom-config-group"/> even further. Grouping items 
+      helps to a certain extent, but using global aliases for users, 
       commands and hosts is the most efficient way to keep a clean and 
       lean &sudo; configuration.
     </para>
@@ -318,61 +282,62 @@ ALL   ALL=(ALL) ALL<co xml:id="ALL"/>   # WARNING! Only use this together with '
       procedure applies for any other type of alias (host aliases, command 
       aliases and run as aliases).
     </para>
-
-    <procedure>
-      <step>
-        <para>
-          To add user and command aliases to be used in the example 
-          configuration file, run <command>visudo</command> as system 
-          administrator to edit the global &sudo; configuration file 
-          (<filename>/etc/sudoers</filename>).
-        </para>
-      </step>
-      <step>
-        <para>
-          In the <literal>User_Alias</literal> section, add the following 
-          line to create the <literal>TEAMLEADERS</literal> alias:
-        </para>
-        <screen>User_Alias    TEAMLEADERS = &exampleuser_plain;, &exampleuserII_plain;
+    <example xml:id="ex-sudo-custom-config-alias">
+      <title>Simplify configurations by applying aliases</title>
+      <procedure>
+        <step>
+          <para>
+            To add user and command aliases to be used in the example 
+            configuration file, run <command>visudo</command> as system 
+            administrator to edit the global &sudo; configuration file 
+            (<filename>/etc/sudoers</filename>).
+          </para>
+        </step>
+        <step>
+          <para>
+            In the <literal>User_Alias</literal> section, add the following 
+            line to create the <literal>TEAMLEADERS</literal> alias:
+          </para>
+          <screen>User_Alias    TEAMLEADERS = &exampleuser_plain;, &exampleuserII_plain;
 </screen>
-      </step>
-      <step>
-        <para>
-          In the <literal>Cmnd_Alias</literal> section, add the following 
-          line to create the <literal>USERMANAGEMENT</literal> alias:
-        </para>
-        <screen>Cmnd_Alias    USERMANAGEMENT = /usr/sbin/useradd, /usr/sbin/usermod, /usr/sbin/userdel
+        </step>
+        <step>
+          <para>
+            In the <literal>Cmnd_Alias</literal> section, add the following 
+            line to create the <literal>USERMANAGEMENT</literal> alias:
+          </para>
+          <screen>Cmnd_Alias    USERMANAGEMENT = /usr/sbin/useradd, /usr/sbin/usermod, /usr/sbin/userdel
 </screen>
-      </step>
-      <step>
-        <para>
-          Save your changes and exit <command>visudo</command>.
-        </para>
-      </step>
-      <step>
-        <para>
-          As system administrator, start <command>visudo</command> to edit the 
-          example configuration file:</para>
-        <screen>&prompt.root;<command>visudo -f /etc/sudoers.d/01_usermanagement</command>
+        </step>
+        <step>
+          <para>
+            Save your changes and exit <command>visudo</command>.
+          </para>
+        </step>
+        <step>
+          <para>
+            As system administrator, start <command>visudo</command> to edit the 
+            example configuration file:
+          </para>
+          <screen>&prompt.root;<command>visudo -f /etc/sudoers.d/01_usermanagement</command>
 </screen>
-      </step>
-      <step>
-        <para>
-           Delete the previous rule and replace it by the following rule that 
-           uses the aliases you have just defined above:
-        </para>
-        <screen>TEAMLEADERS ALL = USERMANAGEMENT
+        </step>
+        <step>
+          <para>
+            Delete the previous rule and replace it by the following rule that 
+            uses the aliases you have just defined above:
+          </para>
+          <screen>TEAMLEADERS ALL = USERMANAGEMENT
 </screen>
-      </step>
-      <step>
-        <para>
-          Save the configuration, leave the editor and open a second shell to test 
-          whether &sudo; honors your new configuration. If you have accidentally 
-          introduced a syntax error, <command>visudo</command> will report it as 
-          soon as you try to save and exit the editor.
-        </para>
-      </step>
-    </procedure>
+        </step>
+        <step>
+          <para>
+            Save the configuration, leave the editor and open a second shell to test 
+            whether &sudo; honors your new configuration.
+          </para>
+        </step>
+      </procedure>
+    </example>
     <note>
       <title>For more information</title>
       <para>

--- a/tasks/sudo-creating-custom-configuration.xml
+++ b/tasks/sudo-creating-custom-configuration.xml
@@ -31,7 +31,7 @@ in the assembly -->
   <warning>
     <title>Example configurations for demonstration purposes only</title>
     <para>
-      Be aware that the example rules outlined below are purely for 
+      Note that the example rules outlined below are purely for 
       demonstration purposes. Use them to understand the general syntax of 
       &sudo; configuration files. Do not use them in real-world setups, because they 
       do not reflect the complexity of real-world environments.

--- a/tasks/sudo-creating-custom-configuration.xml
+++ b/tasks/sudo-creating-custom-configuration.xml
@@ -23,18 +23,18 @@ in the assembly -->
     <abstract><!-- can be changed via merge in the assembly -->
       <para>
        Learn how to build a simple example custom &sudo; configuration and 
-       expand it step-by-step. Create groups and how use aliases to keep your 
-       custom configuration lean and efficient.
+       expand it step by step. Create groups and use aliases to keep your custom 
+       configuration lean and efficient.
       </para>
     </abstract>
   </info>
   <warning>
-    <title>Example configurations for demonstration purposes only</title>
+    <title>Example configurations are for demonstration purposes only</title>
     <para>
       Note that the example rules outlined below are purely for 
       demonstration purposes. Use them to understand the general syntax of 
       &sudo; configuration files. Do not use them in real-world setups, because they 
-      do not reflect the complexity of real-world environments.
+      do not reflect the complexity of these environments.
     </para>
   </warning>
   <section xml:id="sudo-creating-custom-configuration-bp">
@@ -64,7 +64,7 @@ in the assembly -->
             Custom configurations must reside under the 
             <filename>/etc/sudoers.de</filename> to be pulled in by &sudo;. 
             Settings in the custom configuration files take precedence over the 
-            ones in the default confiugation in <filename>/etc/sudoers</filename>. 
+            ones in the default configuration in <filename>/etc/sudoers</filename>. 
           </para>
         </listitem>
       </varlistentry>
@@ -76,7 +76,7 @@ in the assembly -->
             Use leading zeroes to establish the order in which the files are read. For example,
             <filename>01_myfirstconfig</filename> is parsed before
             <filename>10_myotherconfig</filename>. If a directive has been set 
-            in one file that is read before another file that contains 
+            in a file that is read before another file that contains 
             conflicting information, the last-read directive is applied. 
           </para>
         </listitem>
@@ -96,15 +96,15 @@ in the assembly -->
   <section xml:id="sudo-creating-custom-config-single-user">
     <title>Create a user-specific configuration file</title>
     <para>
-      Create a &sudo; configuration file that allows &exampleuser; to use the 
-      <command>useradd</command> command with their own password instead of the 
-      &rootuser; password. 
+      Create a &sudo; configuration file that allows a nomal user (&exampleuser;) 
+      to use the <command>useradd</command> command with their own password 
+      instead of the &rootuser; password. 
     </para>
     <procedure>
       <step>
         <para>
           As system administrator (&rootuser;), create a custom configuration 
-          file to hold the new user-specific directives by starting 
+          file that holds the new user-specific directives by starting 
           <command>visudo</command>. Use both numbering and a descriptive name:
         </para>
         <screen>
@@ -137,7 +137,7 @@ tux<co xml:id="who"/> ALL<co xml:id="where"/> = /usr/sbin/useradd<co xml:id="wha
               Specify one or several (separated by commas) hosts. Use 
               (fully qualified) host names or IP addresses. Use 
               <literal>ALL</literal> to enforce this setting globally 
-              across all hosts and use <literal>!</literal> for negations.
+              across all hosts. Use <literal>!</literal> for negations.
             </para>
           </callout>
           <callout arearefs="what">
@@ -185,7 +185,7 @@ tux<co xml:id="who"/> ALL<co xml:id="where"/> = /usr/sbin/useradd<co xml:id="wha
         </calloutlist>
         <para>
           To enable the specified user to use the command without entering any 
-          password, add the <literal>NOPASSWD:</literal> in front ot the 
+          password at all, add the <literal>NOPASSWD:</literal> in front ot the 
           executable's path. By default, &sudo; requires the user to enter a 
           password, so that you do not have to specify the <literal>PASSWD:</literal>
           option explicitely. It is only required, if you specify a list 
@@ -210,7 +210,7 @@ ALL   ALL=(ALL) ALL<co xml:id="ALL"/>   # WARNING! Only use this together with '
             <para>
               When active, this flag requires the user to enter the password of 
               the target user, i.e. &rootuser;. This flag is enabled by default on 
-              any &productname; system. When disabled, no password is required.
+              any &productname; system.
             </para>
           </callout>
           <callout arearefs="ALL">
@@ -232,7 +232,7 @@ ALL   ALL=(ALL) ALL<co xml:id="ALL"/>   # WARNING! Only use this together with '
        </para>
       </step>
       <step>
-        <para>To check for any errors with your overall &sudo; configuration:
+        <para>To check for any errors in your overall &sudo; configuration, run:
         </para>
         <screen>&prompt.root;<command>visudo -c</command>
 /etc/sudoers: parsed OK
@@ -258,7 +258,7 @@ ALL   ALL=(ALL) ALL<co xml:id="ALL"/>   # WARNING! Only use this together with '
       so that a group of named users can run the <command>useradd</command> 
       command without the need for the &rootuser; password. Also, add the 
       <command>usermod</command> and <command>userdel</command> to the list of 
-      commands available to said group.
+      commands available to this group.
     </para>
     <procedure>
       <step>
@@ -271,7 +271,7 @@ ALL   ALL=(ALL) ALL<co xml:id="ALL"/>   # WARNING! Only use this together with '
       </step>
       <step>
         <para>
-          To add more users to a rule, just use a comma-separated list:
+          To add more users to the rule, just use a comma-separated list:
         </para>
         <screen>&exampleuser_plain;, &exampleuserII_plain; ALL = /usr/sbin/useradd
 </screen>
@@ -358,7 +358,8 @@ ALL   ALL=(ALL) ALL<co xml:id="ALL"/>   # WARNING! Only use this together with '
       </step>
       <step>
         <para>
-           Adjust the rule to use the aliases:
+           Delete the previous rule and replace it by the following rule that 
+           uses the aliases you have just defined above:
         </para>
         <screen>TEAMLEADERS ALL = USERMANAGEMENT
 </screen>
@@ -372,5 +373,13 @@ ALL   ALL=(ALL) ALL<co xml:id="ALL"/>   # WARNING! Only use this together with '
         </para>
       </step>
     </procedure>
+    <note>
+      <title>For more information</title>
+      <para>
+        Find a more detailed description of the &sudo; configuration syntax in 
+        <xref linkend="sudo-user-authorization"/> and refer to the man page of 
+        &sudo;.
+      </para>
+    </note>
   </section>
 </topic>

--- a/tasks/sudo-creating-custom-configuration.xml
+++ b/tasks/sudo-creating-custom-configuration.xml
@@ -97,6 +97,82 @@ in the assembly -->
     <procedure>
       <step>
         <para>
+          Create a custom configuration file to hold the new user-specific 
+          directives by starting <command>visudo</command>. 
+          Use both numbering and a descriptive name:
+        </para>
+        <screen>
+&sudoprompt; visudo -f /etc/sudoers.d/01_usermanagement
+</screen>
+      </step>
+      <step>
+        <para>
+          Create a rule that allows &exampleuser; to execute the 
+          <command>/usr/sbin/useradd</command> binary in the entire environment 
+          that this &sudo; configuration is applied to:
+        </para>
+        <screen>
+tux<co xml:id="who"/> ALL<co xml:id="where"/> = /usr/sbin/useradd<co xml:id="what"/>
+</screen>
+        <para>
+
+        </para>
+        <calloutlist>
+          <callout arearefs="who">
+            <para>
+              Specify the user or group. Users by name or <literal>#UID</literal> 
+              groups by <literal>%GROUPNAME</literal>. If you have several items here, separate them with commas.
+              To negate entries, use <literal>!</literal>. 
+            </para>
+          </callout>
+          <callout arearefs="where">
+            <para>
+              Specify one or several (separated by commas) hosts.
+            </para>
+          </callout>
+          <callout arearefs="what">
+            <para></para>
+          </callout>
+        </calloutlist>
+      </step>
+    </procedure>
+  </section>
+    <section xml:id="sudo-creating-custom-config-group">
+    <title>Create custom configurations by grouping items</title>
+    <para>
+      Modify the example from <xref linkend="sudo-creating-custom-config-single-user"/> 
+      so that a group of named users can run the <command>useradd</command> 
+      command without the need for the &rootuser; password. Also, add the 
+      <command>usermod</command> and <command>userdel</command> to the list of 
+      commands available to said group.
+    </para>
+    <procedure>
+      <step>
+        <para>
+          
+        </para>
+      </step>
+      <step>
+        <para>
+          A second step.
+        </para>
+      </step>
+      <step>
+        <para>
+          A third step.
+        </para>
+      </step>
+    </procedure>
+  </section>
+    <section xml:id="sudo-creating-custom-config-aliases">
+    <title>Simplify configurations by applying aliases</title>
+    <para>
+      Use aliases to simplify your custom configuration from 
+      <xref linkend="sudo-creating-custom-config-group"/> even further. 
+    </para>
+    <procedure>
+      <step>
+        <para>
           A step.
         </para>
       </step>

--- a/tasks/sudo-creating-custom-configuration.xml
+++ b/tasks/sudo-creating-custom-configuration.xml
@@ -16,7 +16,7 @@
  xmlns:xlink="http://www.w3.org/1999/xlink"
  xmlns:trans="http://docbook.org/ns/transclusion">
   <info>
-    <title>Creating and understanding custom &sudo; configurations</title><!-- can be changed via merge
+    <title>Creating custom &sudo; configurations</title><!-- can be changed via merge
 in the assembly -->
     <!-- add author's e-mail -->
     <meta name="maintainer" content="jana.jaeger@suse.com" its:translate="no"/>

--- a/tasks/sudo-creating-custom-configuration.xml
+++ b/tasks/sudo-creating-custom-configuration.xml
@@ -16,21 +16,27 @@
  xmlns:xlink="http://www.w3.org/1999/xlink"
  xmlns:trans="http://docbook.org/ns/transclusion">
   <info>
-    <title>Creating custom &sudo; configurations</title><!-- can be changed via merge
+    <title>Creating and understanding custom &sudo; configurations</title><!-- can be changed via merge
 in the assembly -->
     <!-- add author's e-mail -->
     <meta name="maintainer" content="jana.jaeger@suse.com" its:translate="no"/>
     <abstract><!-- can be changed via merge in the assembly -->
       <para>
-       Learn how to build a simple custom &sudo; configuration and expand it 
-       step-by-step. You will be creating a custom configuration that allows a 
-       certain user to run the <command>useradd</command>, <command>usermod</command> 
-       and <command>userdel</command> command with &sudo; and their own password
-       instead of the &rootuser;'s password. Learn how to create groups and how 
+       Learn how to build a simple example custom &sudo; configuration and 
+       expand it step-by-step. Learn how to create groups and how 
        to use aliases to keep your custom configuration lean and efficient.
       </para>
     </abstract>
   </info>
+  <warning>
+    <title>Example configurations for demonstration purposes only</title>
+    <para>
+      Be aware that the example rules outlined below are purely for 
+      demonstration purposes. Use them to understand the general syntax of 
+      &sudo; configuration files. Do not use them in real-world setups, because they 
+      do not reflect the complexity of real-world environments.
+    </para>
+  </warning>
   <section xml:id="sudo-creating-custom-configuration-bp">
     <title>&sudo; configuration best practices</title>
     <para>
@@ -97,12 +103,12 @@ in the assembly -->
     <procedure>
       <step>
         <para>
-          Create a custom configuration file to hold the new user-specific 
-          directives by starting <command>visudo</command>. 
-          Use both numbering and a descriptive name:
+          As system administrator (&rootuser;), create a custom configuration 
+          file to hold the new user-specific directives by starting 
+          <command>visudo</command>. Use both numbering and a descriptive name:
         </para>
         <screen>
-&prompt.sudo; visudo -f /etc/sudoers.d/01_usermanagement
+&prompt.root;visudo -f /etc/sudoers.d/01_usermanagement
 </screen>
       </step>
       <step>
@@ -177,6 +183,17 @@ tux<co xml:id="who"/> ALL<co xml:id="where"/> = /usr/sbin/useradd<co xml:id="wha
             </para>
           </callout>
         </calloutlist>
+        <para>
+          To enable the specified user to use the command without entering any 
+          password, add the <literal>NOPASSWD:</literal> in front ot the 
+          executable's path. By default, &sudo; requires the user to enter a 
+          password, so that you do not have to specify the <literal>PASSWD:</literal>
+          option explicitely. Adding it is just required if you specify a list 
+          of executables that should behave differently:
+        </para>
+        <screen>
+&exampleuser_plain; ALL = PASSWD: /usr/sbin/useradd, NOPASSWD: /usr/bin/zypper
+</screen>
       </step>
       <step>
         <para>
@@ -199,7 +216,7 @@ ALL   ALL=(ALL) ALL<co xml:id="ALL"/>   # WARNING! Only use this together with '
           <callout arearefs="ALL">
             <para>
               This rule allows all users on all hosts to run all executables as 
-              any user. Use this rule only together with 
+              any user. Never use this rule without
               <literal>Defaults targetpw</literal>. Disabling this rule lets 
               &sudo; check for user-specific rules with user-specific permissions.
             </para>
@@ -207,9 +224,15 @@ ALL   ALL=(ALL) ALL<co xml:id="ALL"/>   # WARNING! Only use this together with '
         </calloutlist>
       </step>
       <step>
+       <para>
+        Save the configuration, leave the editor and open a second shell to test 
+        whether &sudo; honors your new configuration.
+       </para>
+      </step>
+      <step>
         <para>Check whether there are any errors with your &sudo; configuration:
         </para>
-        <screen>&prompt.sudo;visudo -c
+        <screen>&prompt.root;visudo -c
 /etc/sudoers: parsed OK
 /etc/sudoers.d/01_usermanagement: parsed OK
 ...
@@ -223,9 +246,6 @@ ALL   ALL=(ALL) ALL<co xml:id="ALL"/>   # WARNING! Only use this together with '
           contains an error, <command>visudo</command> reports the file
           name, line number and error description of the affected file.
         </para>
-      </step>
-      <step>
-        <para></para>
       </step>
     </procedure>
   </section>
@@ -241,18 +261,47 @@ ALL   ALL=(ALL) ALL<co xml:id="ALL"/>   # WARNING! Only use this together with '
     <procedure>
       <step>
         <para>
-          
+          To modify the example configuration, open it with 
+          <command>visudo</command>:
+        </para>
+        <screen>&prompt.root;visudo /etc/sudoers.d/01_usermanagement
+</screen>
+      </step>
+      <step>
+        <para>
+          To add more users to a rule, just use a comma-separated list:
+        </para>
+        <screen>&exampleuser_plain;, &exampleuserII_plain; ALL = /usr/sbin/useradd
+</screen>
+      </step>
+      <step>
+        <para>
+          To allow the listed users to execute a list of commands, specify the 
+          commands as a comma-separated list:
+        </para>
+        <screen>&exampleuser_plain;, &exampleuserII_plain; ALL = /usr/sbin/useradd, /usr/sbin/usermod, /usr/sbin/userdel
+</screen>
+        <para>
+          The <literal>PASSWD:</literal> option is again implied for all the 
+          commands specified on this line. If one or more commands on the same 
+          line should not require a password, then you would have to explicitely 
+          specify the <literal>PASSWD:</literal> and <literal>NOPASSWD:</literal> 
+          with every single one of them.
         </para>
       </step>
       <step>
         <para>
-          A second step.
+          Save the configuration, leave the editor and open a second shell to test 
+        whether &sudo; honors your new configuration.
         </para>
       </step>
       <step>
-        <para>
-          A third step.
+        <para>Check whether there are any errors with your &sudo; configuration:
         </para>
+        <screen>&prompt.root;visudo -c
+/etc/sudoers: parsed OK
+/etc/sudoers.d/01_usermanagement: parsed OK
+...</screen>
       </step>
     </procedure>
   </section>
@@ -261,22 +310,62 @@ ALL   ALL=(ALL) ALL<co xml:id="ALL"/>   # WARNING! Only use this together with '
     <para>
       Use aliases to simplify your custom configuration from 
       <xref linkend="sudo-creating-custom-config-group"/> even further. 
+      Grouping items helps to a certain extent, but using aliases for users, 
+      commands and hosts is the most efficient way to keep a clean and 
+      lean &sudo; configuration.
     </para>
+
     <procedure>
       <step>
         <para>
-          A step.
+          To modify the example configuration, open it with 
+          <command>visudo</command>:
         </para>
+        <screen>&prompt.root;visudo /etc/sudoers.d/01_usermanagement
+</screen>
+        <para>
+          The current example from <xref linkend="sudo-creating-custom-config-group"/> 
+          looks like this:
+        </para>
+        <screen>&exampleuser_plain;, &exampleuserII_plain; ALL = /usr/sbin/useradd, /usr/sbin/usermod, /usr/sbin/userdel
+</screen>
+      </step>
+      <step>        
+        <para>
+          To create an alias for a group of users, add the following line above 
+          the rule itself:
+        </para>
+        <screen>User_Alias TEAMLEADERS = &exampleuser_plain;, &exampleuserII_plain;
+</screen>
       </step>
       <step>
         <para>
-          A second step.
+          To add an alias for a group of commands, add the following line above 
+          the rule itself:
         </para>
+        <screen>Cmnd_Alias USERMANAGEMENT = /usr/sbin/useradd, /usr/sbin/usermod, /usr/sbin/userdel
+</screen>
       </step>
       <step>
         <para>
-          A third step.
+          Adjust the rule to use the aliases:
         </para>
+        <screen>TEAMLEADERS ALL = USERMANAGEMENT
+</screen>
+      </step>
+      <step>
+        <para>
+          Save the configuration, leave the editor and open a second shell to test 
+          whether &sudo; honors your new configuration.
+        </para>
+      </step>
+      <step>
+        <para>Check whether there are any errors with your &sudo; configuration:
+        </para>
+        <screen>&prompt.root;visudo -c
+/etc/sudoers: parsed OK
+/etc/sudoers.d/01_usermanagement: parsed OK
+...</screen>
       </step>
     </procedure>
   </section>

--- a/tasks/sudo-start-shell-as-root.xml
+++ b/tasks/sudo-start-shell-as-root.xml
@@ -29,7 +29,7 @@
     </abstract>
   </info>
   <section xml:id="task-sudo-start-shell-as-root-introduction">
-    <title>Introduction</title>
+    <title>Difference between <command>sudo -s</command> and <command>sudo -i</command></title>
     <para>
       Having to enter &sudo; every time you want to run a command as &rootuser;
       can become tedious. Instead, you can use one of the built-in mechanisms to
@@ -54,7 +54,7 @@
     </itemizedlist>
     <para>
       With both commands, the shell is started with a new environment, and
-      you are logged in as superuser. Any subsequent command that is executed within
+      you are logged in as &rootuser;. Any subsequent command that is executed within
       that shell is run with elevated privileges without having to enter the
       password again. This environment is terminated when you close the shell,
       and you must enter the password again for another &sudo; command.

--- a/tasks/sudo-start-shell-as-root.xml
+++ b/tasks/sudo-start-shell-as-root.xml
@@ -83,9 +83,9 @@
       following command:
     </para>
 <screen>
-<prompt>&exampleuser_plain;:~ &gt; </prompt>sudo -s
+<prompt>&exampleuser_plain;:~ &gt; </prompt><command>sudo -s</command>
 [sudo] password for root:
-<prompt>root:/home/tux # </prompt>exit
+<prompt>root:/home/tux # </prompt><command>exit</command>
 <prompt>&exampleuser_plain;:~ &gt; </prompt>
 </screen>
     <para>
@@ -111,9 +111,9 @@
       To run a command with <command>sudo -i</command>, enter the following:
     </para>
 <screen>
-<prompt>&exampleuser_plain;:~ &gt; </prompt>sudo -i
+<prompt>&exampleuser_plain;:~ &gt; </prompt><command>sudo -i</command>
 [sudo] password for root:
-<prompt>root:~ # </prompt>exit
+<prompt>root:~ # </prompt><command>exit</command>
 <prompt>&exampleuser_plain;:~ &gt; </prompt>
 </screen>
     <para>

--- a/tasks/sudo-start-shell-as-root.xml
+++ b/tasks/sudo-start-shell-as-root.xml
@@ -84,7 +84,7 @@
     </para>
 <screen>
 <prompt>&exampleuser_plain;:~ &gt; </prompt>sudo -s
-root's password:
+[sudo] password for root:
 <prompt>root:/home/tux # </prompt>exit
 <prompt>&exampleuser_plain;:~ &gt; </prompt>
 </screen>
@@ -112,7 +112,7 @@ root's password:
     </para>
 <screen>
 <prompt>&exampleuser_plain;:~ &gt; </prompt>sudo -i
-root's password:
+[sudo] password for root:
 <prompt>root:~ # </prompt>exit
 <prompt>&exampleuser_plain;:~ &gt; </prompt>
 </screen>

--- a/tasks/sudo-troubleshoot.xml
+++ b/tasks/sudo-troubleshoot.xml
@@ -37,23 +37,21 @@
      configuration files provided by the package manager (containing
      <option>.</option>), or with an editor's temporary or backup files (ending
      in <option>~</option>). Make sure that the names of your custom
-     configuration files neither contain nor end in these characters and rename
-     them, if they do.
+     configuration files neither contain nor end in these characters. If they do, 
+     rename them.
     </para>
   </section>
     <section xml:id="sudo-troubleshooting-order-includes">
     <title>Custom directives conflict</title>
     <para>
-      The time when a &sudo; configuration directive is applied is determined
-      by the order in which the respective configuration file is read.
-      Directives in a file located under <filename>/etc/sudoers.d/</filename>
-      take precedence over the same directives in
-      <filename>/etc/sudoers</filename>. If custom directives stated in
-      <filename>/etc/sudoers.d/</filename> do not work, check the order
-       in which the files are read and fix it, if necessary.
+      The order in which the configuration files are read determines when a 
+      &sudo; configuration directive is applied. Directives in a file located 
+      under <filename>/etc/sudoers.d/</filename> take precedence over the same 
+      directives in <filename>/etc/sudoers</filename>. If custom directives 
+      stated in <filename>/etc/sudoers.d/</filename> do not work, check the order
+      in which the files are read using <command>visudo -c</command>. Adjust 
+      the order, if necessary.
     </para>
-    <para>To check the order in which the configurations are parsed, use the
-    <command>visudo -c</command> command.</para>
   </section>
   <section xml:id="sudo-troubleshooting-locked-out">
     <title>Locked out due to broken &sudo; configuration</title>

--- a/tasks/sudo-troubleshoot.xml
+++ b/tasks/sudo-troubleshoot.xml
@@ -9,7 +9,7 @@
 <!-- refer to README.md for file and id naming conventions -->
 <!-- metadata is dealt with on the assembly level -->
 <topic xml:id="sudo-troubleshooting"
- role="reference" xml:lang="en"
+ role="task" xml:lang="en"
  xmlns="http://docbook.org/ns/docbook" version="5.2"
  xmlns:its="http://www.w3.org/2005/11/its"
  xmlns:xi="http://www.w3.org/2001/XInclude"

--- a/tasks/sudo-without-root-password.xml
+++ b/tasks/sudo-without-root-password.xml
@@ -40,10 +40,10 @@
     <title>Giving &sudo; privileges to a user without the &rootuser; password</title>
     <step>
       <para>
-        As a system administrator, add the user to the
+        As system administrator, add the user to the
         <systemitem class="groupname">wheel</systemitem> group:
       </para>
-<screen>&prompt.sudo; <command>usermod -aG wheel <replaceable>USERNAME</replaceable></command></screen>
+<screen>&prompt.root; <command>usermod -aG wheel <replaceable>USERNAME</replaceable></command></screen>
     </step>
     <step>
       <para>
@@ -64,10 +64,10 @@
     </step>
     <step>
       <para>
-        Edit the <filename>sudoers</filename> configuration file using
-        <command>visudo</command>:
+        As system administrator, edit the <filename>sudoers</filename> 
+        configuration file using <command>visudo</command>:
       </para>
-<screen>&prompt.sudo;<command>visudo</command></screen>
+<screen>&prompt.root;<command>visudo</command></screen>
     </step>
     <step>
       <para>
@@ -96,17 +96,15 @@
       </para>
 <screen>%wheel ALL=(ALL:ALL) NOPASSWD: ALL</screen>
     </step>
-    <step>
-      <para>
-        Save the changes, but do not exit the editor. Before exiting the
-        editor, start another terminal session and verify that you and the
-        target user can use elevated privileges.
-      </para>
-      <result>
+      <step>
         <para>
-          After the verification is successful, exit the editor.
+          Save the configuration, leave the editor and open a second shell to 
+          test whether &sudo; honors your new configuration.
         </para>
-      </result>
-    </step>
+        <para>
+          In case your configuration contained a syntax error, <command>visudo</command>
+          would report it when you try to close the file.
+        </para>
+      </step>
   </procedure>
 </topic>


### PR DESCRIPTION
### Description

Split the humongous sudo article into a user view and an admin view. This PR handles the admin part. This is an entirely new piece, no redirects necessary. 

Or if we need them, then this would be the 
Old URL: https://documentation.suse.com/smart/systems-management/html/task-configure-sudo/task-configure-sudo.html

