### PR TITLE
Fix validation of RAID assembly

### DIFF
--- a/articles/raid.asm.xml
+++ b/articles/raid.asm.xml
@@ -160,8 +160,8 @@
       <module resourceref="_raid-configuring-stripe-size" renderas="section"/>
       <module resourceref="_raid-monitoring-raids" renderas="section"/>
       <module resourceref="_legal"/>
-      <module resourceref="_gfdl" renderas="appendix"/>
     </module>
     <!-- Troubleshooting -->
+    <module resourceref="_gfdl" renderas="appendix"/>
   </structure>
 </assembly>


### PR DESCRIPTION
### Description

Positon GFDL module (id=_gfdl) at the right position
