### PR TITLE
Added tip on non-root user (bsc#1211059)

### DIFF
--- a/concepts/cockpit-authetication.xml
+++ b/concepts/cockpit-authetication.xml
@@ -35,9 +35,9 @@
       primarily log in as such user. The same applies to logging in to
       &cockpit;. If you need <emphasis>Administrative access</emphasis> in
       &cockpit;, click <guimenu>Limited access</guimenu> in the top right menu
-      and unlock it by entering &rootuser; password. Refer to <xref
-      linkend="alp-pre-deployment-considerations-root-ssh-login"/> for details
-      about &rootuser; access.
+      and unlock it by entering &rootuser; password. Refer to <link
+      xlink:href="https://documentation.suse.com/alp/dolomite/html/alp-dolomite/concept-alp-deployment.html#alp-pre-deployment-considerations-root-ssh-login"/>
+      for details about &rootuser; access.
     </para>
   </tip>
   <para>

--- a/concepts/cockpit-authetication.xml
+++ b/concepts/cockpit-authetication.xml
@@ -27,6 +27,17 @@
       </para>
     </abstract>
   </info>
+  <tip os="alp-dolomite">
+    <title>Access &cockpit; as a non-privileged user</title>
+    <para>
+      It is a good practice to create a non-privileged user
+      account&mdash;preferably during &productnameshort; deployment&mdash;and
+      primarily log in as such user. The same applies to logging in to
+      &cockpit;. If you need <emphasis>Administrative access</emphasis> in
+      &cockpit;, click <guimenu>Limited access</guimenu> in the top right menu
+      and unlock it by entering &rootuser; password.
+    </para>
+  </tip>
   <para>
     &cockpit; enables you to log in directly to each machine that can expose the
     9090 port. This machine is sometimes referred to as the primary server. It

--- a/concepts/cockpit-authetication.xml
+++ b/concepts/cockpit-authetication.xml
@@ -35,7 +35,9 @@
       primarily log in as such user. The same applies to logging in to
       &cockpit;. If you need <emphasis>Administrative access</emphasis> in
       &cockpit;, click <guimenu>Limited access</guimenu> in the top right menu
-      and unlock it by entering &rootuser; password.
+      and unlock it by entering &rootuser; password. Refer to <xref
+      linkend="alp-pre-deployment-considerations-root-ssh-login"/> for details
+      about &rootuser; access.
     </para>
   </tip>
   <para>


### PR DESCRIPTION
### Description
This update adds tip on a good practice of having a non-privileged user account to log in to system/services


### Are there any relevant issues/feature requests?

* bsc#1211059

### Is this (based on) existing content?

* old xml:id...
* old URL...
