### PR TITLE
Make meta name=category consistent

### DIFF
--- a/articles/alp-dolomite.asm.xml
+++ b/articles/alp-dolomite.asm.xml
@@ -220,7 +220,7 @@
       containerized workloads.</meta>
       <meta name="social-descr" its:translate="yes">A minimal immutable
       self-healing OS</meta>
-      <meta name="category" content="systems-management" its:translate="no"/>
+      <meta name="category" content="Systems Management" its:translate="no"/>
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>

--- a/articles/sle-minimal-vm.asm.xml
+++ b/articles/sle-minimal-vm.asm.xml
@@ -85,7 +85,7 @@
       <meta name="description" its:translate="yes">Learn what &slsa; &minvm; can do for you</meta>
       <meta name="social-descr" its:translate="yes">Getting to know &slsa; &minvm;</meta>
       <!-- suitable category, comma-separated list of categories -->
-      <meta name="category" content="systems-management" its:translate="no"/>
+      <meta name="category" content="Systems Management" its:translate="no"/>
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>

--- a/articles/virt-scenario-creating-customized-vm-guests.asm.xml
+++ b/articles/virt-scenario-creating-customized-vm-guests.asm.xml
@@ -68,7 +68,7 @@
       <meta name="title" its:translate="no">&productname;</meta>
       <meta name="description"  its:translate="yes">Creating customized &vmguest;s using &virt-scenario;</meta>
       <meta name="social-descr" its:translate="yes">Creating customized &vmguest;s using &virt-scenario;</meta>
-      <meta name="category" content="systems-management" its:translate="no"/>
+      <meta name="category" content="Systems Management" its:translate="no"/>
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>


### PR DESCRIPTION
### Description

Some categories in `<meta name="category" .../>` had a different spelling than the rest. Used the following command line to detect this:

```
$ xml sel --text -N d=http://docbook.org/ns/docbook \
    -t -v "//d:meta[@name='category']/@content" --nl articles/*.asm.xml | sort | uniq
```


