### PR TITLE
Templates: Provide values for name="category" metadata

### DIFF
--- a/templates/articles/assembly.asm.xml
+++ b/templates/articles/assembly.asm.xml
@@ -79,6 +79,7 @@
           </revdescription>
         </revision>
       </revhistory>
+      <!-- For a full list, see https://confluence.suse.com/x/aQDWNg -->
       <!-- TODO: provide a listing of possible and validatable meta entry values. Maybe in our geekodoc repo? -->
       <!-- add author's e-mail -->
       <meta name="maintainer" content="" its:translate="no"/>
@@ -107,7 +108,12 @@
       <meta name="title" its:translate="yes">short title for SEO and social media, max. 55 chars</meta>
       <meta name="description" its:translate="yes">short description, max. 150 chars</meta>
       <meta name="social-descr" its:translate="yes">ultrashort description for social media, max 55 chars</meta>
-      <!-- suitable category, comma-separated list of categories -->
+      <!-- suitable category, comma-separated list of categories. Possible values are:
+           Storage, High Availability, Network, Virtualization & Cloud, Access Cloud, Security,
+           Systems Management, Deployment & Upgrade, System Tuning & Performance, Containerization,
+           SAP,
+           (Desktop Applications), (Rancher)
+      -->
       <meta name="category" content="Systems Management" its:translate="no"/>
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>


### PR DESCRIPTION
### Description

In a 1:1 session, Daria brought up the idea to add all possible category values for `<meta name="category"/>` in the template. At the moment, we have "Systems Management" which doesn't apply for all docs.

As it's a bit hard to know all valid values (we don't validate them), I've added them in the comment. Additionally, there is a link to the respective Confluence page for details (and up-to-date information).


### Are there any relevant issues/feature requests?

n/a
