### PR TITLE
Add yast hotplug procedure to network bond article

### DIFF
--- a/tasks/network-bond-enable-hotplug.xml
+++ b/tasks/network-bond-enable-hotplug.xml
@@ -23,6 +23,9 @@
         However, before you can replace the interface, you must configure the networking
         setup to recognize when a new device is added.
       </para>
+      <para>
+        You can enable hotplugging either manually or with &yast;.
+      </para>
     </abstract>
   </info>
   <section xml:id="network-bond-enable-hotplug-requirements">
@@ -35,8 +38,77 @@
      </listitem>
     </itemizedlist>
   </section>
+  <section xml:id="network-bond-enable-hotplug-yast">
+    <title>Enabling hotplugging for network bond members with &yast;</title>
+    <procedure>
+      <step>
+        <para>
+          Start the graphical version of &yast;, or run the command <command>yast2</command>
+          to start YaST in text mode.
+        </para>
+      </step>
+      <step>
+        <para>
+          Select <menuchoice><guimenu>System</guimenu><guimenu>Network Settings</guimenu></menuchoice>.
+          The <guimenu>Overview</guimenu> tab shows the existing devices. If devices are already
+          configured in a bond, this is stated in the <guimenu>Note</guimenu> column.
+        </para>
+      </step>
+      <step xml:id="network-bond-enable-hotplug-step-edit">
+        <para>
+          Select one of the bond members, then select <guimenu>Edit</guimenu>.
+          The <guimenu>Network Card Setup</guimenu> menu opens.
+        </para>
+      </step>
+      <step>
+        <para>
+          Switch to the <guimenu>General</guimenu> tab.
+        </para>
+      </step>
+      <step>
+        <para>
+          Under <guimenu>Udev rules</guimenu>, select <guimenu>Change</guimenu>.
+          A dialog box opens.
+        </para>
+      </step>
+      <step>
+        <para>
+          In the dialog box, choose the <guimenu>BusID</guimenu> option, then select
+          <guimenu>OK</guimenu>.
+        </para>
+      </step>
+      <step>
+        <para>
+          Make sure that <guimenu>Activate device</guimenu> is set to <literal>On Hotplug</literal>.
+        </para>
+      </step>
+      <step xml:id="network-bond-enable-hotplug-step-confirm">
+        <para>
+          Select <guimenu>Next</guimenu> to return to the <guimenu>Network Settings</guimenu> menu.
+          When you select the bond member now, the bottom pane shows the device's details,
+          including the bus ID.
+        </para>
+      </step>
+      <step>
+        <para>
+          Repeat <xref linkend="network-bond-enable-hotplug-step-edit"/> to
+          <xref linkend="network-bond-enable-hotplug-step-confirm"/> for all bond members.
+        </para>
+      </step>
+      <step>
+        <para>
+        Select <guimenu>OK</guimenu> to confirm your changes.
+        </para>
+      </step>
+      <step>
+        <para>
+          Select <guimenu>Quit</guimenu> or press <keycap>F9</keycap> to close &yast;.
+        </para>
+      </step>
+    </procedure>
+  </section>
   <section xml:id="network-bond-enable-hotplug-procedure">
-    <title>Enabling hotplugging for network bond members</title>
+    <title>Enabling hotplugging for network bond members manually</title>
     <procedure>
       <step>
         <para>
@@ -77,7 +149,10 @@ ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="eth*", NAME="eth1"</screen>
         </para>
       </step>
     </procedure>
-    <para>
+  </section>
+  <section xml:id="network-bond-enable-hotplug-summary">
+    <title>Summary</title>
+        <para>
       When one of the bond member interfaces is removed from the system, the kernel removes it from
       the bond automatically. When a new card is added to the system, <systemitem>udev</systemitem>
       uses the bus-based persistent name rule to rename the interface to the name of the bond member,


### PR DESCRIPTION
### Description

Added the yast hoptlugging procedure from the HA docs, including testing and updating it.

It's in no way HA-specific. 


### Are there any relevant issues/feature requests?

No


### Is this (based on) existing content?

* sec-ha-netbond-hotpug-yast
* https://documentation.suse.com/sle-ha/15-SP5/html/SLE-HA-all/cha-ha-netbonding.html#sec-ha-netbond-hotpug-yast
