### PR TITLE
Update networking-nmcli.xml - nmcli networking

### DIFF
--- a/references/networking-nmcli.xml
+++ b/references/networking-nmcli.xml
@@ -561,7 +561,7 @@
               <option>check</option> is used, &nm; performs a new check of the
               state. Otherwise, the last detected state is displayed.
             </para>
-<screen>&prompt.root;nmcli networking state</screen>
+<screen>&prompt.root;nmcli networking connectivity</screen>
             <para>
               Possible states are the following:
             </para>


### PR DESCRIPTION
Command
nmcli networking state
does no longer exist in Leap Micro 5.5. Use
nmcli networking connectivity 
instead

bsc#1217723