### PR TITLE
Fix typo in systemctl command

### DIFF
--- a/tasks/systemd-timer-user.xml
+++ b/tasks/systemd-timer-user.xml
@@ -46,7 +46,7 @@
 &prompt.user;systemctl --user enable ~/.config/systemd/user/helloworld.timer
 &prompt.user;systemctl --user list-timers
 &prompt.user;journalctl --user -u helloworld.*
-&prompt.user;systemctl-analyze ~/.config/systemd/user/helloworld.timer</screen>
+&prompt.user;systemd-analyze verify ~/.config/systemd/user/helloworld.timer</screen>
     </listitem>
   </itemizedlist>
   <important>


### PR DESCRIPTION
Command systemd-analyze has been introduced a bit above.   
Here I think there is a typo, as systemctl-analyze doesn't seem to exist.  I also think a command should be passed to systemd-analyze, like verify

### Description

Fix a typo