### PR TITLE
Add temporary descriptions to two systemd articles 

### DIFF
--- a/xml/reference-systemctl-enable-disable-services.xml
+++ b/xml/reference-systemctl-enable-disable-services.xml
@@ -22,10 +22,11 @@
      <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
      <dm:component>Smart Docs</dm:component>
      <dm:product>Documentation</dm:product>
-     <dm:assignee>carla.schroder@suse.com</dm:assignee>
+     <dm:assignee>amrita.sakthivel@suse.com</dm:assignee>
     </dm:bugtracker>
     <dm:translation>no</dm:translation>
    </dm:docmanager>
+   <meta name="description" its:translate="yes">Learn how to enable and disable systemd services.</meta>
  </info>
 
  <section xml:id="environment-systemd-enable-disable-services">

--- a/xml/reference-systemctl-managing-targets.xml
+++ b/xml/reference-systemctl-managing-targets.xml
@@ -22,10 +22,13 @@
      <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
      <dm:component>Smart Docs</dm:component>
      <dm:product>Documentation</dm:product>
-     <dm:assignee>carla.schroder@suse.com</dm:assignee>
+     <dm:assignee>amrita.sakthivel@suse.com</dm:assignee>
     </dm:bugtracker>
     <dm:translation>no</dm:translation>
    </dm:docmanager>
+   <meta name="description" its:translate="yes">&systemd; targets are different 
+   states that a system can boot into. They are controlled with the systemctl 
+   command.</meta>
  </info>
 
  <section xml:id="environment-systemctl-managing-targets">


### PR DESCRIPTION
### Description

Old Smart Docs don't have description meta data. A few of them show up in our all-time top 10 list. In order for them to be properly displayed on the new portal, we need description meta data.
This PR adds the missing meta data to the systemd-based articles in that list.

### Are there any relevant issues/feature requests?

* jsc#DOCTEAM-1101

