### PR TITLE
add missing descriptions to zypper articles

### DIFF
--- a/xml/concept-zypper.xml
+++ b/xml/concept-zypper.xml
@@ -26,6 +26,9 @@
    </dm:bugtracker>
    <dm:translation>no</dm:translation>
   </dm:docmanager>
+  <meta name="description" its:translate="yes">&zypper; is a command-line tool 
+  for installing, updating and removing software packages and for managing 
+  repositories.</meta>
  </info>
  <section xml:id="environment-zypper">
   <title>Environment</title>

--- a/xml/reference-zypper-install.xml
+++ b/xml/reference-zypper-install.xml
@@ -26,6 +26,8 @@
    </dm:bugtracker>
    <dm:translation>no</dm:translation>
   </dm:docmanager>
+  <meta name="description" its:translate="yes">Learn how to perform package and 
+  repository management tasks using the &zypper; command-line.</meta>
  </info>
  <section xml:id="environment-zypper-install">
   <title>Environment</title>


### PR DESCRIPTION
### Description

Old Smart Docs don't carry description metadata that's needed to generate proper portal tiles. This PR fixes the issue for the high-ranking zypper articles.

### Are there any relevant issues/feature requests?

* jsc#1101


