### PR TITLE
rootless-podman: Explain how to delegate controllers

### DIFF
--- a/concepts/rootless-podman-configure-containers.xml
+++ b/concepts/rootless-podman-configure-containers.xml
@@ -59,6 +59,12 @@ cgroup</screen>
       using the <command>grub2-mkconfig -o /boot/grub2/grub.cfg</command>
       command.
     </para>
+    <para>
+      Even on setups of &productname; with cgroup v2, the default
+      configuration delegates no controllers  to user sessions
+      (for performance reasons) and chosen controllers should be enabled explicitly,
+      <link xlink:href="https://documentation.suse.com/sles/html/SLES-tuning/cha-tuning-cgroups.html#sec-cgroups-user-sessions"/>.
+    </para>
   </section>
   <section xml:id="rootless-podman-troubleshoot-read-access">
     <title>Enabling read access to the &scc; credentials</title>


### PR DESCRIPTION
### Description

As per PED-2276 we prefer performance over rootless config, thus controllers should be enabled manually.


### Are there any relevant issues/feature requests?

* jsc#PED-2276


### Is this (based on) existing content?

* --