### PR TITLE
GNOME add productname to title

### DIFF
--- a/articles/GNOME-getting-started.asm.xml
+++ b/articles/GNOME-getting-started.asm.xml
@@ -113,7 +113,7 @@
         <productname version="X.Y">&productname;</productname>
       </meta>
       <meta name="title" its:translate="yes">How to get started with
-        &gnome; Desktop</meta>
+        &gnome; Desktop on &productname;</meta>
       <meta name="description" its:translate="yes">Learn about the default
         configurations of <productname>&gnome; Desktop</productname>, how to
         customize the settings to your needs, and how to perform regular


### PR DESCRIPTION
Description

Add &productname; entity back to title. Was removed because of validation errors


