### PR TITLE
update Bugzilla pointers 

### DIFF
--- a/DC-Micro-network-configuration
+++ b/DC-Micro-network-configuration
@@ -8,7 +8,7 @@ STRUCTID="network-configuration-nm-marble"
 SRC_DIR="articles"
 
 ## Profiling
-PROFOS="slemicro_6.0"
+PROFOS="slmicro"
 
 #PROFARCH="x86_64;zseries;power;aarch64"
 

--- a/DC-network-configuration-nm
+++ b/DC-network-configuration-nm
@@ -8,7 +8,7 @@ STRUCTID="network-configuration-nm"
 SRC_DIR="articles"
 
 ## Profiling
-PROFOS="slemicro"
+PROFOS="sles"
 #PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location

--- a/articles/GNOME-getting-started.asm.xml
+++ b/articles/GNOME-getting-started.asm.xml
@@ -131,7 +131,7 @@
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
           <dm:component>Documentation</dm:component>
-          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
+          <dm:product condition="16.0" os="sles">SUSE Linux Enterprise Server 16.0</dm:product>
           <!-- provide your BUGZILLA e-mail address, otherwise this does not work correctly-->
           <dm:assignee>julia.faltenbacher@suse.com</dm:assignee>
         </dm:bugtracker>

--- a/articles/GNOME-getting-started.asm.xml
+++ b/articles/GNOME-getting-started.asm.xml
@@ -131,7 +131,7 @@
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
           <dm:component>Documentation</dm:component>
-          <dm:product condition="16.0" os="sles">SUSE Linux Enterprise Server 16.0</dm:product>
+          <dm:product os="sles">SUSE Linux Enterprise Server 16.0</dm:product>
           <!-- provide your BUGZILLA e-mail address, otherwise this does not work correctly-->
           <dm:assignee>julia.faltenbacher@suse.com</dm:assignee>
         </dm:bugtracker>

--- a/articles/GNOME-getting-started.asm.xml
+++ b/articles/GNOME-getting-started.asm.xml
@@ -110,7 +110,7 @@
       </meta>
       <!-- enter one or more product names and version -->
       <meta name="productname" its:translate="no">
-        <productname version="X.Y">&productname;</productname>
+        <productname version="16.0" os="sles">&productname;</productname>
       </meta>
       <meta name="title" its:translate="yes">How to get started with
         &gnome; Desktop on &productname;</meta>
@@ -130,8 +130,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
           <!-- provide your BUGZILLA e-mail address, otherwise this does not work correctly-->
           <dm:assignee>julia.faltenbacher@suse.com</dm:assignee>
         </dm:bugtracker>

--- a/articles/Micro-deployment-images.asm.xml
+++ b/articles/Micro-deployment-images.asm.xml
@@ -73,8 +73,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Micro 6.0</dm:product>
           <dm:assignee>jsindelarova@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/Micro-upgrade.asm.xml
+++ b/articles/Micro-upgrade.asm.xml
@@ -108,8 +108,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Micro 6.0</dm:product>
           <!-- provide your BUGZILLA e-mail address, otherwise this does not work correctly-->
           <dm:assignee>jsindelarova@suse.com</dm:assignee>
         </dm:bugtracker>

--- a/articles/SELinux-policy.asm.xml
+++ b/articles/SELinux-policy.asm.xml
@@ -108,9 +108,9 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
-          <dm:assignee>maintainer@suse.com</dm:assignee>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
+          <dm:assignee>jsindelarova@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>no</dm:translation>
       </dm:docmanager>

--- a/articles/SELinux-troubleshooting.asm.xml
+++ b/articles/SELinux-troubleshooting.asm.xml
@@ -57,7 +57,7 @@
       <!-- <subtitle>Subtitle if necessary</subtitle>-->
       <!-- Create revision history to enable versioning; add most recent entries at the top. -->
       <!-- Check https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-revhistory for detailed instructions-->
-      <revhistory xml:id="rh-USE-ROOT-ID">
+      <revhistory xml:id="rh-setroubleshoot">
         <revision><date>2024-02-29</date>
           <revdescription>
             <itemizedlist>
@@ -109,8 +109,9 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product os="slmicro">SUSE Linux Enterprise Micro 6.0</dm:product>
+          <dm:product os="slemicro">SUSE Linux Enterprise Micro 5.5</dm:product>
           <!-- provide your BUGZILLA e-mail address, otherwise this does not work correctly-->
           <dm:assignee>jsindelarova@suse.com</dm:assignee>
         </dm:bugtracker>

--- a/articles/SELinux.asm.xml
+++ b/articles/SELinux.asm.xml
@@ -90,7 +90,7 @@
       </revhistory>
       <!-- TODO: provide a listing of possible and validatable meta entry values. Maybe in our geekodoc repo? -->
       <!-- add author's e-mail -->
-      <meta name="maintainer" content="jsindelarova@suse.common" its:translate="no"/>
+      <meta name="maintainer" content="jsindelarova@suse.com" its:translate="no"/>
       <!-- ISO date of last update as YYYY-MM-DD -->
       <meta name="updated" content="2023-10-26" its:translate="no"/>
       <!-- this does not work yet. Use the dm tags listed below for now
@@ -131,9 +131,9 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
-          <dm:assignee>maintainer@suse.com</dm:assignee>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Micro 6.0</dm:product>
+          <dm:assignee>jsindelarova@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>no</dm:translation>
       </dm:docmanager>
@@ -143,7 +143,7 @@
           <term>WHAT?</term>
           <listitem>
             <para>
-              The topic provdes basic information about Security-Enhanced Linux.
+              The topic provides basic information about Security-Enhanced Linux.
             </para>
           </listitem>
         </varlistentry>

--- a/articles/SLE-Micro-public-cloud.asm.xml
+++ b/articles/SLE-Micro-public-cloud.asm.xml
@@ -92,8 +92,9 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product os="slmicro">SUSE Linux Enterprise Micro 6.0</dm:product>
+          <dm:product os="slemicro">SUSE Linux Enterprise Micro 5.5</dm:product>
           <dm:assignee>jsindelarova@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>no</dm:translation>

--- a/articles/SLE_Micro_admin.asm.xml
+++ b/articles/SLE_Micro_admin.asm.xml
@@ -219,7 +219,8 @@
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
           <dm:component>Documentation</dm:component>
-          <dm:product>SUSE Linux Enterprise Micro 6.0</dm:product>
+          <dm:product condition="5.5">SUSE Linux Enterprise Micro 5.5</dm:product>
+          <dm:product condition="5.4">SUSE Linux Enterprise Micro 5.4</dm:product>
           <dm:assignee>jsindelarova@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>no</dm:translation>

--- a/articles/SLE_Micro_admin.asm.xml
+++ b/articles/SLE_Micro_admin.asm.xml
@@ -200,7 +200,7 @@
         <phrase>&power;</phrase>
       </meta>
       <meta name="productname" its:translate="no">
-        <productname  os="slemicro">&productname;</productname>        
+        <productname os="slemicro">&productname;</productname>
       </meta>
       <meta name="title" its:translate="yes">Administration of &productnameshort;</meta>
       <meta name="description" its:translate="yes">Describes the administration tasks on &productnameshort;</meta>
@@ -218,8 +218,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Micro 6.0</dm:product>
           <dm:assignee>jsindelarova@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>no</dm:translation>

--- a/articles/cockpit-slemicro.asm.xml
+++ b/articles/cockpit-slemicro.asm.xml
@@ -203,8 +203,9 @@ type="application/relax-ng-compact-syntax"?>
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product os="slmicro">SUSE Linux Enterprise Micro 6.0</dm:product>
+          <dm:product os="slemicro">SUSE Linux Enterprise Micro 5.5</dm:product>
           <dm:assignee>jsindelarova@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/cockpit-slemicro.asm.xml
+++ b/articles/cockpit-slemicro.asm.xml
@@ -205,7 +205,8 @@ type="application/relax-ng-compact-syntax"?>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
           <dm:component>Documentation</dm:component>
           <dm:product os="slmicro">SUSE Linux Enterprise Micro 6.0</dm:product>
-          <dm:product os="slemicro">SUSE Linux Enterprise Micro 5.5</dm:product>
+          <dm:product os="slemicro" condition="5.5">SUSE Linux Enterprise Micro 5.5</dm:product>
+          <dm:product os="slemicro" condition="5.4">SUSE Linux Enterprise Micro 5.4</dm:product>
           <dm:assignee>jsindelarova@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/cpu-check-temperature.asm.xml
+++ b/articles/cpu-check-temperature.asm.xml
@@ -75,7 +75,7 @@
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
           <dm:component>Documentation</dm:component>
           <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
-          <dm:assignee>dmitri.popov@suse.com</dm:assignee>
+          <dm:assignee>daria.vladykina@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>
       </dm:docmanager>

--- a/articles/cpu-check-temperature.asm.xml
+++ b/articles/cpu-check-temperature.asm.xml
@@ -73,9 +73,9 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
-          <dm:assignee>dpopov@suse.com</dm:assignee>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
+          <dm:assignee>dmitri.popov@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>
       </dm:docmanager>

--- a/articles/deployment-raw-images-bare-metal.asm.xml
+++ b/articles/deployment-raw-images-bare-metal.asm.xml
@@ -135,8 +135,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Micro 6.0</dm:product>
           <dm:assignee>jsindelarova@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/deployment-raw-images-ibm-dasd.asm.xml
+++ b/articles/deployment-raw-images-ibm-dasd.asm.xml
@@ -139,9 +139,9 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
-          <!-- provide your BUGZILLA e-mail address, otherwise this does not work correctly-->
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Micro 6.0</dm:product>
+<!-- provide your BUGZILLA e-mail address, otherwise this does not work correctly-->
           <dm:assignee>jsindelarova@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/deployment-raw-images-virtual-machines.asm.xml
+++ b/articles/deployment-raw-images-virtual-machines.asm.xml
@@ -150,8 +150,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Micro 6.0</dm:product>
 <!-- provide your BUGZILLA e-mail address, otherwise this does not work correctly-->
           <dm:assignee>jsindelarova@suse.com</dm:assignee>
         </dm:bugtracker>

--- a/articles/deployment-selfinstall-images-bare-metal.asm.xml
+++ b/articles/deployment-selfinstall-images-bare-metal.asm.xml
@@ -129,8 +129,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Micro 6.0</dm:product>
           <dm:assignee>jsindelarova@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/docker-compose.asm.xml
+++ b/articles/docker-compose.asm.xml
@@ -127,8 +127,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Micro 6.0</dm:product>
           <!-- provide your BUGZILLA e-mail address, otherwise this does not work correctly-->
           <dm:assignee>jsindelarova@suse.com</dm:assignee>
         </dm:bugtracker>

--- a/articles/elemental.asm.xml
+++ b/articles/elemental.asm.xml
@@ -109,9 +109,10 @@ usage of &productnameshort; with Rancher OS management.</meta>
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
-          <dm:assignee>maintainer@suse.com</dm:assignee>
+          <dm:component>Documentation</dm:component>
+          <dm:product os="slmicro">SUSE Linux Enterprise Micro 6.0</dm:product>
+          <dm:product os="slemicro">SUSE Linux Enterprise Micro 5.5</dm:product>
+          <dm:assignee>jsindelarova@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>
       </dm:docmanager>

--- a/articles/forward-root-mail.asm.xml
+++ b/articles/forward-root-mail.asm.xml
@@ -107,9 +107,9 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
-          <dm:assignee>maintainer@suse.com</dm:assignee>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
+          <dm:assignee>cwickert@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>
       </dm:docmanager>

--- a/articles/freeradius-setup-server.asm.xml
+++ b/articles/freeradius-setup-server.asm.xml
@@ -126,8 +126,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
           <dm:assignee>shalaka.harne@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/http-boot-setting-up-server.asm.xml
+++ b/articles/http-boot-setting-up-server.asm.xml
@@ -67,7 +67,7 @@ https://documentation.suse.com/sles/15-SP5/html/SLES-all/cha-deployment-prep-uef
       <title>Setting up an HTTP Boot server</title>
       <!-- Create revision history to enable versioning; add most recent entries at the top. -->
       <!-- Check https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-revhistory for detailed instructions-->
-      <revhistory xml:id="rh-USE-ROOT-ID">
+      <revhistory xml:id="rh-http-boot-setting-up-server">
         <revision><date>2023-12-15</date>
           <revdescription>
             <para>
@@ -103,8 +103,8 @@ https://documentation.suse.com/sles/15-SP5/html/SLES-all/cha-deployment-prep-uef
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
           <dm:assignee>tahlia.richardson@suse.com</dm:assignee>
        </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/keylime.asm.xml
+++ b/articles/keylime.asm.xml
@@ -126,8 +126,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Micro 6.0</dm:product>
           <!-- provide your BUGZILLA e-mail address, otherwise this does not work correctly-->
           <dm:assignee>jsindelarova@suse.com</dm:assignee>
        </dm:bugtracker>

--- a/articles/logging-managing-system-logfiles.asm.xml
+++ b/articles/logging-managing-system-logfiles.asm.xml
@@ -191,8 +191,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Micro 6.0</dm:product>
           <!-- provide your BUGZILLA e-mail address, otherwise this does not work correctly-->
           <dm:assignee>jsindelarova@suse.com</dm:assignee>
         </dm:bugtracker>

--- a/articles/manage-vm-on-commandline.asm.xml
+++ b/articles/manage-vm-on-commandline.asm.xml
@@ -117,8 +117,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
           <dm:assignee>shalaka.harne@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/network-bond-managing-devices.asm.xml
+++ b/articles/network-bond-managing-devices.asm.xml
@@ -83,8 +83,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
           <dm:assignee>tahlia.richardson@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/network-configuration-nm.asm.xml
+++ b/articles/network-configuration-nm.asm.xml
@@ -114,7 +114,8 @@
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
           <dm:component>Documentation</dm:component>
-          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
+          <dm:product os="sles">SUSE Linux Enterprise Server 16.0</dm:product>
+          <dm:product os="slmicro">SUSE Linux Enterprise Micro 6.0</dm:product>
           <dm:assignee>jsindelarova@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/network-configuration-nm.asm.xml
+++ b/articles/network-configuration-nm.asm.xml
@@ -113,8 +113,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
           <dm:assignee>jsindelarova@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/network-configuration-nm.asm.xml
+++ b/articles/network-configuration-nm.asm.xml
@@ -115,7 +115,6 @@
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
           <dm:component>Documentation</dm:component>
           <dm:product os="sles">SUSE Linux Enterprise Server 16.0</dm:product>
-          <dm:product os="slmicro">SUSE Linux Enterprise Micro 6.0</dm:product>
           <dm:assignee>jsindelarova@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>
@@ -260,8 +259,8 @@ About &nm;
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product os="slmicro">SUSE Linux Enterprise Micro 6.0</dm:product>
           <dm:assignee>jsindelarova@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/network-interface-predictable-naming.asm.xml
+++ b/articles/network-interface-predictable-naming.asm.xml
@@ -84,8 +84,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
           <dm:assignee>tbazant@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/network-team-managing-devices.asm.xml
+++ b/articles/network-team-managing-devices.asm.xml
@@ -81,8 +81,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
           <dm:assignee>tahlia.richardson@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/ntp-time-synchronization.asm.xml
+++ b/articles/ntp-time-synchronization.asm.xml
@@ -96,7 +96,7 @@
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
           <dm:component>Documentation</dm:component>
-          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>          
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
           <dm:assignee>tbazant@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/ntp-time-synchronization.asm.xml
+++ b/articles/ntp-time-synchronization.asm.xml
@@ -96,7 +96,8 @@
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
           <dm:component>Documentation</dm:component>
-          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
+          <dm:product os="sles">SUSE Linux Enterprise Server 16.0</dm:product>
+          <dm:product os="slmicro">SUSE Linux Enterprise Micro 6.0</dm:product>
           <dm:assignee>tbazant@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/ntp-time-synchronization.asm.xml
+++ b/articles/ntp-time-synchronization.asm.xml
@@ -96,8 +96,7 @@
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
           <dm:component>Documentation</dm:component>
-          <dm:product os="sles">SUSE Linux Enterprise Server 16.0</dm:product>
-          <dm:product os="slmicro">SUSE Linux Enterprise Micro 6.0</dm:product>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>          
           <dm:assignee>tbazant@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/ntp-time-synchronization.asm.xml
+++ b/articles/ntp-time-synchronization.asm.xml
@@ -253,8 +253,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Micro 6.0</dm:product>
           <dm:assignee>tbazant@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/ntp-time-synchronization.asm.xml
+++ b/articles/ntp-time-synchronization.asm.xml
@@ -95,8 +95,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
           <dm:assignee>tbazant@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/pam.asm.xml
+++ b/articles/pam.asm.xml
@@ -122,9 +122,10 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
-          <dm:assignee>maintainer@suse.com</dm:assignee>
+          <dm:component>Documentation</dm:component>
+          <dm:product os="slmicro">SUSE Linux Enterprise Micro 6.0</dm:product>
+          <dm:product os="sles">SUSE Linux Enterprise Server 16.0</dm:product>
+          <dm:assignee>amrita.sakthivel@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>
       </dm:docmanager>

--- a/articles/performance-copilot-metrics.asm.xml
+++ b/articles/performance-copilot-metrics.asm.xml
@@ -135,8 +135,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Micro 6.0</dm:product>
           <!-- provide your BUGZILLA e-mail address, otherwise this does not work correctly-->
           <dm:assignee>jsindelarova@suse.com</dm:assignee>
        </dm:bugtracker>

--- a/articles/podman.asm.xml
+++ b/articles/podman.asm.xml
@@ -158,8 +158,9 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product os="slmicro">SUSE Linux Enterprise Micro 6.0</dm:product>
+          <dm:product os="sles">SUSE Linux Enterprise Server 16.0</dm:product>
           <!-- provide your BUGZILLA e-mail address, otherwise this does not work correctly-->
           <dm:assignee>jsindelarova@suse.com</dm:assignee>
        </dm:bugtracker>

--- a/articles/raid.asm.xml
+++ b/articles/raid.asm.xml
@@ -246,8 +246,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Micro 6.0</dm:product>
           <dm:assignee>jsindelarova@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/raid.asm.xml
+++ b/articles/raid.asm.xml
@@ -114,8 +114,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
           <dm:assignee>jsindelarova@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/rootless-podman.asm.xml
+++ b/articles/rootless-podman.asm.xml
@@ -89,9 +89,9 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
-          <dm:assignee>dpopov@suse.com</dm:assignee>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
+          <dm:assignee>dmitri.popov@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>
       </dm:docmanager>

--- a/articles/security-slemicro.asm.xml
+++ b/articles/security-slemicro.asm.xml
@@ -176,8 +176,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Micro 5.5</dm:product>
           <dm:assignee>jsindelarova@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/sle-minimal-vm.asm.xml
+++ b/articles/sle-minimal-vm.asm.xml
@@ -107,9 +107,9 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
-          <dm:assignee>dpopov@suse.com</dm:assignee>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
+          <dm:assignee>dmitri.popov@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>
       </dm:docmanager>

--- a/articles/snapper-basic-concepts.asm.xml
+++ b/articles/snapper-basic-concepts.asm.xml
@@ -82,8 +82,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
           <dm:assignee>daria.vladykina@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/snapper-basic-concepts.asm.xml
+++ b/articles/snapper-basic-concepts.asm.xml
@@ -83,7 +83,8 @@
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
           <dm:component>Documentation</dm:component>
-          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
+          <dm:product os="sles">SUSE Linux Enterprise Server 16.0</dm:product>
+          <dm:product os="slmicro">SUSE Linux Enterprise Micro 6.0</dm:product>
           <dm:assignee>daria.vladykina@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/subnet-manager-configuring.asm.xml
+++ b/articles/subnet-manager-configuring.asm.xml
@@ -74,8 +74,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
           <dm:assignee>tbazant@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/sudo-configure-superuser-privileges.asm.xml
+++ b/articles/sudo-configure-superuser-privileges.asm.xml
@@ -94,9 +94,9 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
-          <dm:assignee>fs@suse.com</dm:assignee>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
+          <dm:assignee>jana.jaeger@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>
       </dm:docmanager>

--- a/articles/sudo-configure-superuser-privileges.asm.xml
+++ b/articles/sudo-configure-superuser-privileges.asm.xml
@@ -95,7 +95,8 @@
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
           <dm:component>Documentation</dm:component>
-          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
+          <dm:product os="sles">SUSE Linux Enterprise Server 16.0</dm:product>
+          <dm:product os="slmicro">SUSE Linux Enterprise Micro 6.0</dm:product>
           <dm:assignee>jana.jaeger@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/sudo-run-commands-as-superuser.asm.xml
+++ b/articles/sudo-run-commands-as-superuser.asm.xml
@@ -73,11 +73,10 @@
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
           <dm:component>Documentation</dm:component>
-          <dm:product condition="16.0" os="sles">SUSE Linux Enterprise Server 16.0</dm:product>
-          <dm:product condition="16.0" os="sles4sap">SUSE Linux Enterprise Server for SAP Applications 16.0</dm:product>
-          <dm:product condition="6.1" os="slmicro">SUSE Linux Enterprise Micro 6.1</dm:product>
-          <dm:product condition="6.0" os="slmicro">SUSE Linux Enterprise Micro 6.0</dm:product>
-          <dm:product condition="5.5" os="slemicro">SUSE Linux Enterprise Micro 5.5</dm:product>
+          <dm:product os="sles">SUSE Linux Enterprise Server 16.0</dm:product>
+          <dm:product os="sles4sap">SUSE Linux Enterprise Server for SAP Applications 16.0</dm:product>
+          <dm:product os="slmicro">SUSE Linux Enterprise Micro 6.0</dm:product>
+          <dm:product os="slemicro">SUSE Linux Enterprise Micro 5.5</dm:product>
           <dm:assignee>julia.faltenbacher@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/sudo-run-commands-as-superuser.asm.xml
+++ b/articles/sudo-run-commands-as-superuser.asm.xml
@@ -73,8 +73,11 @@
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
           <dm:component>Documentation</dm:component>
-          <dm:product os="sles">SUSE Linux Enterprise Server 16.0</dm:product>
-          <dm:product os="slmicro">SUSE Linux Enterprise Micro 6.0</dm:product>
+          <dm:product condition="16.0" os="sles">SUSE Linux Enterprise Server 16.0</dm:product>
+          <dm:product condition="16.0" os="sles4sap">SUSE Linux Enterprise Server for SAP Applications 16.0</dm:product>
+          <dm:product condition="6.1" os="slmicro">SUSE Linux Enterprise Micro 6.1</dm:product>
+          <dm:product condition="6.0" os="slmicro">SUSE Linux Enterprise Micro 6.0</dm:product>
+          <dm:product condition="5.5" os="slemicro">SUSE Linux Enterprise Micro 5.5</dm:product>
           <dm:assignee>julia.faltenbacher@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/sudo-run-commands-as-superuser.asm.xml
+++ b/articles/sudo-run-commands-as-superuser.asm.xml
@@ -72,9 +72,9 @@
 <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
-          <dm:assignee>fs@suse.com</dm:assignee>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
+          <dm:assignee>julia.faltenbacher@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>
       </dm:docmanager>

--- a/articles/sudo-run-commands-as-superuser.asm.xml
+++ b/articles/sudo-run-commands-as-superuser.asm.xml
@@ -73,7 +73,8 @@
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
           <dm:component>Documentation</dm:component>
-          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
+          <dm:product os="sles">SUSE Linux Enterprise Server 16.0</dm:product>
+          <dm:product os="slmicro">SUSE Linux Enterprise Micro 6.0</dm:product>
           <dm:assignee>julia.faltenbacher@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/supportconfig.asm.xml
+++ b/articles/supportconfig.asm.xml
@@ -106,7 +106,9 @@
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
           <dm:component>Documentation</dm:component>
-          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
+          <dm:product os="sles">SUSE Linux Enterprise Server 16.0</dm:product>
+          <dm:product os="slmicro">SUSE Linux Enterprise Micro 6.0</dm:product>
+          <dm:product os="slemicro">SUSE Linux Enterprise Micro 5.5</dm:product>
           <dm:assignee>jsindelarova@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/supportconfig.asm.xml
+++ b/articles/supportconfig.asm.xml
@@ -105,8 +105,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
           <dm:assignee>jsindelarova@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/systemd-basics.asm.xml
+++ b/articles/systemd-basics.asm.xml
@@ -127,7 +127,7 @@
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
           <dm:component>Documentation</dm:component>
           <dm:product os="sles">SUSE Linux Enterprise Server 16.0</dm:product>
-          <dm:product os="slemicro">SUSE Linux Enterprise Micro 5.5</dm:product>
+          <dm:product os="slmicro">SUSE Linux Enterprise Micro 6.0</dm:product>
           <dm:assignee>amrita.sakthivel@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/systemd-basics.asm.xml
+++ b/articles/systemd-basics.asm.xml
@@ -125,8 +125,9 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product os="sles">SUSE Linux Enterprise Server 16.0</dm:product>
+          <dm:product os="slemicro">SUSE Linux Enterprise Micro 5.5</dm:product>
           <dm:assignee>amrita.sakthivel@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/systemd-management.asm.xml
+++ b/articles/systemd-management.asm.xml
@@ -111,7 +111,9 @@
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
           <dm:component>Documentation</dm:component>
-          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
+          <dm:product os="sles">SUSE Linux Enterprise Server 16.0</dm:product>
+          <dm:product os="slemicro">SUSE Linux Micro 5.5</dm:product>
+          <dm:product os="slmicro">SUSE Linux Micro 6.0</dm:product>
           <dm:assignee>amrita.sakthivel@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/systemd-management.asm.xml
+++ b/articles/systemd-management.asm.xml
@@ -110,8 +110,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
           <dm:assignee>amrita.sakthivel@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/systemd-securing.asm.xml
+++ b/articles/systemd-securing.asm.xml
@@ -88,8 +88,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
 <!-- provide your BUGZILLA e-mail address, otherwise this does not work correctly-->
           <dm:assignee>tbazant@suse.com</dm:assignee>
         </dm:bugtracker>

--- a/articles/systemd-timer-working-with.asm.xml
+++ b/articles/systemd-timer-working-with.asm.xml
@@ -86,7 +86,7 @@
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
           <dm:component>Documentation</dm:component>
           <dm:product os="sles">SUSE Linux Enterprise Server 16.0</dm:product>
-          <dm:product os="slemicro">SUSE Linux Enterprise Micro 5.5</dm:product>
+          <dm:product os="slmicro">SUSE Linux Enterprise Micro 6.0</dm:product>
           <dm:assignee>fs@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/systemd-timer-working-with.asm.xml
+++ b/articles/systemd-timer-working-with.asm.xml
@@ -84,8 +84,9 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager" its:translate="no">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product os="sles">SUSE Linux Enterprise Server 16.0</dm:product>
+          <dm:product os="slemicro">SUSE Linux Enterprise Micro 5.5</dm:product>
           <dm:assignee>fs@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/tls-certificates.asm.xml
+++ b/articles/tls-certificates.asm.xml
@@ -110,8 +110,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
 <!-- provide your BUGZILLA e-mail address, otherwise this does not work correctly-->
           <dm:assignee>tbazant@suse.com</dm:assignee>
         </dm:bugtracker>

--- a/articles/toolbox-container.asm.xml
+++ b/articles/toolbox-container.asm.xml
@@ -26,12 +26,12 @@
     </resource>
   </resources>
   <!-- Tasks -->
-  <resources>toolbox-usage
+  <resources>
     <resource xml:id="_toolbox-starting-container" href="../tasks/toolbox-starting-container.xml">
       <description>Creating the container</description>
     </resource>
     <resource xml:id="_toolbox-usage" href="../tasks/toolbox-usage.xml">
-      <description>Usage</description>
+      <description>Toolbox usage</description>
     </resource>
   </resources>
   
@@ -111,8 +111,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Micro 6.0</dm:product>
           <!-- provide your BUGZILLA e-mail address, otherwise this does not work correctly-->
           <dm:assignee>maintainer@suse.com</dm:assignee>
        </dm:bugtracker>

--- a/articles/transactional-updates.asm.xml
+++ b/articles/transactional-updates.asm.xml
@@ -128,8 +128,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Micro 6.0</dm:product>
 <!-- provide your BUGZILLA e-mail address, otherwise this does not work correctly-->
           <dm:assignee>jsindelarova@suse.com</dm:assignee>
         </dm:bugtracker>

--- a/articles/ulp-livepatching.asm.xml
+++ b/articles/ulp-livepatching.asm.xml
@@ -110,8 +110,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
           <dm:assignee>jsindelarova@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>no</dm:translation>

--- a/articles/virt-scenario-creating-customized-vm-guests.asm.xml
+++ b/articles/virt-scenario-creating-customized-vm-guests.asm.xml
@@ -84,8 +84,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
           <dm:assignee>tbazant@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/virtual-disk-cache-mode-configure.asm.xml
+++ b/articles/virtual-disk-cache-mode-configure.asm.xml
@@ -80,8 +80,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
           <dm:assignee>tbazant@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/virtualization.asm.xml
+++ b/articles/virtualization.asm.xml
@@ -84,8 +84,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
 <!-- provide your BUGZILLA e-mail address, otherwise this does not work correctly-->
           <dm:assignee>tbazant@suse.com</dm:assignee>
         </dm:bugtracker>

--- a/articles/vm-assign-pci-device.asm.xml
+++ b/articles/vm-assign-pci-device.asm.xml
@@ -91,8 +91,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
 <!-- provide your BUGZILLA e-mail address, otherwise this does not work correctly-->
           <dm:assignee>tbazant@suse.com</dm:assignee>
         </dm:bugtracker>

--- a/articles/vxlan.asm.xml
+++ b/articles/vxlan.asm.xml
@@ -82,8 +82,8 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
 <!-- provide your BUGZILLA e-mail address, otherwise this does not work correctly-->
           <dm:assignee>tbazant@suse.com</dm:assignee>
         </dm:bugtracker>


### PR DESCRIPTION
### Description

Adjust Bugzilla pointers for the articles (as the articles are not really unversioned) and we have suitable Bugzilla products and 'Documentation' components now.  


### Are there any relevant issues/feature requests?

Link to [internal page](https://confluence.suse.com/pages/viewpage.action?pageId=1578729671).

The good news is: Profiling works as expected also for the elements which implement the Bugzilla pointers. If an assembly applies to multiple products and/or product versions, we can profile the `<dm:product/>` elements which then generate the correct Bugzilla link in our HTML outputs (as long as the profiling parameter in the DC file is set correctly).

Along with the Bugzilla information, I fixed also some glitches I spotted along the way (e.g. no or incorrect e-mail address given in `<dm:assignee>` - if the mail address there does _not match_ the one assigned to you in **Bugzilla**, Bugzilla cannot resolve the bug assignee).  

I have updated all assembly files but the 3 (deprecated) ones that specifically apply to ALP:

- alp-dolomite.asm.xml
- cockpit-alp.asm.xml

