### PR TITLE
Smart Docs - Kernel Boot Parameters

### DIFF
--- a/DC-kernel-boot-parameters-modify
+++ b/DC-kernel-boot-parameters-modify
@@ -1,0 +1,17 @@
+# This file originates from the project https://github.com/openSUSE/doc-kit
+# This file can be edited downstream.
+
+MAIN="kernel-boot-parameters-modify.asm.xml"
+# Point to the ID of the <structure> of your assembly
+SRC_DIR="articles"
+ROOTID="kernel-boot-parameters-modify"
+IMG_SRC_DIR="images"
+
+PROFCONDITION="suse-product"
+# PROFCONDITION="suse-product;beta"
+# PROFCONDITION="community-project"
+
+DOCBOOK5_RNG_URI="urn:x-suse:rng:v2:geekodoc-flat"
+
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-kernel-boot-parameters-modify
+++ b/DC-kernel-boot-parameters-modify
@@ -7,9 +7,11 @@ SRC_DIR="articles"
 ROOTID="kernel-boot-parameters-modify"
 IMG_SRC_DIR="images"
 
-PROFCONDITION="suse-product"
-# PROFCONDITION="suse-product;beta"
-# PROFCONDITION="community-project"
+## Profiling
+PROFOS="PRODUCT"
+#PROFCONDITION="PRODUCTNUMBER"
+#STRUCTID="STRUCTURE-ID"
+#PROFARCH="x86_64;zseries;power;aarch64"
 
 DOCBOOK5_RNG_URI="urn:x-suse:rng:v2:geekodoc-flat"
 

--- a/articles/kernel-boot-parameters-modify.asm.xml
+++ b/articles/kernel-boot-parameters-modify.asm.xml
@@ -61,7 +61,7 @@
       <!--subtitle>Subtitle if necessary</subtitle-->
       <!-- Create changelog to enable versioning; add most recent entries at the top. -->
       <revhistory xml:id="rh-kernel-boot-parameters-modify">
-        <revision><revnumber>1</revnumber><date>2024-11-28</date>
+        <revision><date>2024-11-28</date>
           <revdescription>
             <para>
               Initial version
@@ -91,19 +91,18 @@
       <!-- enter the platform identifier or a list of
         identifiers, separated by ; -->
       <meta name="architecture" content="x86" its:translate="no"/>
-      <meta name="productname" its:translate="no">
-        <productname version="15 SP6">&sles;</productname>
+      <meta name="productname" its:translate="no"><productname version="15 SP6">&sles;</productname>
       </meta>
       <meta name="title" its:translate="yes">Modifying kernel boot parameters</meta>
-      <meta name="description" its:translate="yes">How to modify kernel boot parameters for customizing the boot process.</meta>
+      <meta name="description" its:translate="yes">How to modify kernel boot parameters for customizing the boot process</meta>
       <meta name="social-descr" its:translate="yes">Modify kernel boot parameters</meta>
       <!-- suitable category, comma-separated list of categories -->
       <meta name="category" content="Systems Management" its:translate="no"/>
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-              <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
-              <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
+          <dm:component>Documentation</dm:component>
           <dm:assignee>ssarkar@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>
@@ -114,8 +113,9 @@
             <term>WHAT?</term>
             <listitem>
               <para>
-                Concepts, examples and modification process of kernel boot parameters to
-                customize the boot process and the resulting environment.
+                This article introduces the concepts, examples and modification process for kernel
+                boot parameters to customize the boot process and optimize the resulting
+                environment.
               </para>
             </listitem>
           </varlistentry>
@@ -134,7 +134,8 @@
             <term>EFFORT</term>
             <listitem>
               <para>
-                It 15 minutes to fully understand the concepts and the process, and 5 minutes to
+                It takes 15 minutes to fully understand the concepts and the process, and five
+                minutes to modify kernel boot parameters and observe their effect after a reboot.
                 modify kernel boot parameters and observe their effect after a reboot.
               </para>
             </listitem>

--- a/articles/kernel-boot-parameters-modify.asm.xml
+++ b/articles/kernel-boot-parameters-modify.asm.xml
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- file: templates/articles/assembly.xml -->
+<?xml-model href="https://cdn.docbook.org/schema/5.2/rng/assemblyxi.rnc"
+            type="application/relax-ng-compact-syntax"?>
+<!DOCTYPE assembly
+[
+    <!ENTITY % entities SYSTEM "../common/generic-entities.ent">
+    %entities;
+]>
+<!-- refers to legacy doc: <add github link to legacy doc piece, if applicable> -->
+<!-- point back to this document with a similar comment added to your legacy doc piece -->
+<!-- refer to README.md for file and id naming conventions -->
+<assembly version="5.2" xml:lang="en"
+          xmlns:xlink="http://www.w3.org/1999/xlink"
+          xmlns:trans="http://docbook.org/ns/transclusion"
+          xmlns:its="http://www.w3.org/2005/11/its"
+          xmlns="http://docbook.org/ns/docbook">
+  <!-- resources section references all topic chunks used in the final article
+    -->
+  <!-- R E S O U R C E S -->
+  <!-- Glue files -->
+  <resources>
+    <resource xml:id="_kernel-boot-parameters-modify-more-info" href="../glues/kernel-boot-parameters-modify-more-info.xml">
+      <description>For more information</description>
+    </resource>
+  </resources>
+  <!-- Concept files -->
+  <resources>
+    <resource xml:id="_kernel-boot-parameters-modify-introduction" href="../concepts/kernel-boot-parameters-modify-introduction.xml">
+      <description>Introduction to kernel boot parameters</description>
+    </resource>
+    <resource xml:id="_kernel-boot-parameters-modify-difference-linuxrc-parameters" href="../concepts/kernel-boot-parameters-modify-difference-linuxrc-parameters.xml">
+      <description>Difference between kernel boot parameters and linuxrc parameters</description>
+    </resource>
+  </resources>
+  <!-- Tasks -->
+  <resources>
+    <resource xml:id="_kernel-boot-parameters-modify-temporary" href="../tasks/kernel-boot-parameters-modify-temporary.xml">
+      <description>Temporarily modify kernel boot parameters</description>
+    </resource>
+    <resource xml:id="_kernel-boot-parameters-modify-permanent" href="../tasks/kernel-boot-parameters-modify-permanent.xml">
+      <description>Permanently modify kernel boot parameters</description>
+    </resource>
+    <resource xml:id="_kernel-boot-parameters-modify-troubleshoot" href="../tasks/kernel-boot-parameters-modify-troubleshoot.xml">
+      <description>Troubleshooting modified kernel boot parameters</description>
+    </resource>
+  </resources>
+  <!-- Legal -->
+  <resources>
+    <resource href="../common/legal.xml" xml:id="_legal">
+      <description>Legal Notice</description>
+    </resource>
+    <resource href="../common/license_gfdl1.2.xml" xml:id="_gfdl">
+      <description>GNU Free Documentation License</description>
+    </resource>
+  </resources>
+  <!-- S T R U C T U R E -->
+  <structure renderas="article" xml:id="kernel-boot-parameters-modify" xml:lang="en">
+    <merge>
+      <title>Modifying kernel boot parameters</title>
+      <!--subtitle>Subtitle if necessary</subtitle-->
+      <!-- Create changelog to enable versioning; add most recent entries at the top. -->
+      <revhistory xml:id="rh-kernel-boot-parameters-modify">
+        <revision><revnumber>1</revnumber><date>2023-11-28</date>
+          <revdescription>
+            <para>
+              Initial version
+            </para>
+          </revdescription>
+        </revision>
+      </revhistory>
+      <!-- TODO: provide a listing of possible and validatable meta entry values. Maybe in our geekodoc repo? -->
+      <!-- add author's e-mail -->
+      <meta name="maintainer" content="ssarkar@suse.com" its:translate="no"/>
+      <!-- ISO date of last update as YYYY-MM-DD -->
+      <meta name="updated" content="2023-11-28" its:translate="no"/>
+      <!-- this does not work yet. Use the dm tags listed below for now
+        <meta name="bugtracker" its:translate="no">
+        <phrase role="url">https://bugzilla.suse.com/enter_bug.cgi</phrase>
+        <phrase role="component">Non-product-specific documentation</phrase>
+        <phrase role="product">Smart Docs</phrase>
+        <phrase role="assignee">assignee@suse.com</phrase>
+        </meta>
+        -->
+      <!-- not supported, yet. Use dm: tag for now
+        <meta name="translation" its:translate="no">
+        <phrase role="trans">yes</phrase>
+        <phrase role="language">de-de,cs-cz</phrase>
+        </meta>
+        -->
+      <!-- enter the platform identifier or a list of
+        identifiers, separated by ; -->
+      <meta name="architecture" content="x86" its:translate="no"/>
+      <meta name="productname" its:translate="no">
+        <!-- enter product name and version --><productname version="15-SP5">&sles;</productname><productname version="15-SP4">&sles;</productname><productname version="15-SP3">&sles;</productname><productname version="15-SP2">&sles;</productname><productname version="15-SP1">&sles;</productname><productname version="15-GA">&sles;</productname>
+      </meta>
+      <meta name="title" its:translate="yes">Modifying kernel boot parameters</meta>
+      <meta name="description" its:translate="yes">Concepts, examples and modification process of kernel boot
+        parameters for customizing the boot process.</meta>
+      <meta name="social-descr" its:translate="yes">Process for modifying
+      kernel boot parameters</meta>
+      <!-- suitable category, comma-separated list of categories -->
+      <meta name="category" content="Systems Management" its:translate="no"/>
+      <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+        <dm:bugtracker>
+          <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
+          <dm:component>Smart Docs</dm:component>
+          <dm:product>Documentation</dm:product>
+          <dm:assignee>ssarkar@suse.com</dm:assignee>
+        </dm:bugtracker>
+        <dm:translation>yes</dm:translation>
+      </dm:docmanager>
+      <abstract>
+        <variablelist>
+          <varlistentry>
+            <term>WHAT?</term>
+            <listitem>
+              <para>
+                Concepts, examples and modification process of kernel boot parameters for
+                customizing the boot process and the subsequent environment.
+              </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>WHY?</term>
+            <listitem>
+              <para>
+                Modifying kernel boot parameters is essential for achieving specific system
+                configurations and addressing several scenarios, including performance
+                optimization, better hardware compatibility, and troubleshooting issues such as
+                graphics drivers.
+              </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>EFFORT</term>
+            <listitem>
+              <para>
+                It 15 minutes to fully understand the concepts and the process, and 5 minutes to
+                modify kernel boot parameters and observe its effect after reboot.
+              </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>GOAL</term>
+            <listitem>
+              <para>
+                Modify kernel parameters to customize the boot process and the subsequent
+                environment.
+              </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>REQUIREMENTS</term>
+            <listitem>
+              <para>
+                Depending on whether you want to apply changes in kernel boot parameters to the
+                upcoming boot process, or all subsequent boot processes, the requirements are as
+                follows:
+              </para>
+              <itemizedlist>
+                <listitem>
+                  <para>
+                    To change kernel boot parameters on an experimental basis only for the upcoming
+                    boot process, there are no requirements.
+                  </para>
+                </listitem>
+                <listitem>
+                  <para>
+                    To change kernel boot parameters for all subsequent boot processes, you should
+                    have <literal>root</literal> or equivalent administrative privileges.
+                  </para>
+                </listitem>
+              </itemizedlist>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+      </abstract>
+    </merge>
+    <!-- pull in all the topic files you need -->
+    <!-- pick the appropriate type of include to match your needs -->
+    <!-- pull in a topic as is -->
+    <!--concept-->
+    <module resourceref="_kernel-boot-parameters-modify-introduction" renderas="section"/>
+    <!--concept-->
+    <module resourceref="_kernel-boot-parameters-modify-difference-linuxrc-parameters" renderas="section"/>
+    <!--task-->
+    <module resourceref="_kernel-boot-parameters-modify-temporary" renderas="section"/>
+    <!--task-->
+    <module resourceref="_kernel-boot-parameters-modify-permanent" renderas="section"/>
+    <!--task-->
+    <module resourceref="_kernel-boot-parameters-modify-troubleshoot" renderas="section">
+      <merge>
+        <title>Troubleshooting and FAQs</title>
+      </merge>
+    </module>
+    <!--glue-more-info-->
+    <module resourceref="_kernel-boot-parameters-modify-more-info" renderas="section">
+      <merge>
+        <title>For more information</title>
+      </merge>
+    </module>
+    <!--common-->
+    <module resourceref="_legal"/>
+    <!--common-->
+    <module resourceref="_gfdl">
+      <output renderas="appendix"/>
+    </module>
+  </structure>
+</assembly>
+<!--Delete later; adding just for the sake of testing a push-->

--- a/articles/kernel-boot-parameters-modify.asm.xml
+++ b/articles/kernel-boot-parameters-modify.asm.xml
@@ -73,7 +73,7 @@
       <!-- add author's e-mail -->
       <meta name="maintainer" content="ssarkar@suse.com" its:translate="no"/>
       <!-- ISO date of last update as YYYY-MM-DD -->
-      <meta name="updated" content="2023-11-28" its:translate="no"/>
+      <meta name="updated" content="2024-11-28" its:translate="no"/>
       <!-- this does not work yet. Use the dm tags listed below for now
         <meta name="bugtracker" its:translate="no">
         <phrase role="url">https://bugzilla.suse.com/enter_bug.cgi</phrase>
@@ -92,20 +92,19 @@
         identifiers, separated by ; -->
       <meta name="architecture" content="x86" its:translate="no"/>
       <meta name="productname" its:translate="no">
-        <!-- enter product name and version --><productname version="15-SP5">&sles;</productname><productname version="15-SP4">&sles;</productname><productname version="15-SP3">&sles;</productname><productname version="15-SP2">&sles;</productname><productname version="15-SP1">&sles;</productname><productname version="15-GA">&sles;</productname>
+        <productname version="15 SP6">&sles;</productname>
       </meta>
       <meta name="title" its:translate="yes">Modifying kernel boot parameters</meta>
-      <meta name="description" its:translate="yes">Concepts, examples and modification process of kernel boot
+      <meta name="description" its:translate="yes">How to modify kernel boot parameters
         parameters for customizing the boot process.</meta>
-      <meta name="social-descr" its:translate="yes">Process for modifying
-      kernel boot parameters</meta>
+      <meta name="social-descr" its:translate="yes">Modify kernel boot parameters</meta>
       <!-- suitable category, comma-separated list of categories -->
       <meta name="category" content="Systems Management" its:translate="no"/>
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Smart Docs</dm:component>
-          <dm:product>Documentation</dm:product>
+              <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
+              <dm:component>Documentation</dm:component>
           <dm:assignee>ssarkar@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/kernel-boot-parameters-modify.asm.xml
+++ b/articles/kernel-boot-parameters-modify.asm.xml
@@ -93,7 +93,7 @@
       <meta name="architecture" content="x86" its:translate="no"/>
       <meta name="productname" its:translate="no"><productname version="15 SP6">&sles;</productname>
       </meta>
-      <meta name="title" its:translate="yes">Modifying kernel boot parameters</meta>
+      <meta name="title" its:translate="yes">Modifying Kernel Boot Parameters</meta>
       <meta name="description" its:translate="yes">How to modify kernel boot parameters for customizing the boot process</meta>
       <meta name="social-descr" its:translate="yes">Modify kernel boot parameters</meta>
       <!-- suitable category, comma-separated list of categories -->
@@ -136,7 +136,6 @@
               <para>
                 It takes 15 minutes to fully understand the concepts and the process, and five
                 minutes to modify kernel boot parameters and observe their effect after a reboot.
-                modify kernel boot parameters and observe their effect after a reboot.
               </para>
             </listitem>
           </varlistentry>

--- a/articles/kernel-boot-parameters-modify.asm.xml
+++ b/articles/kernel-boot-parameters-modify.asm.xml
@@ -57,11 +57,11 @@
   <!-- S T R U C T U R E -->
   <structure renderas="article" xml:id="kernel-boot-parameters-modify" xml:lang="en">
     <merge>
-      <title>Modifying kernel boot parameters</title>
+      <title>Modifying Kernel Boot Parameters</title>
       <!--subtitle>Subtitle if necessary</subtitle-->
       <!-- Create changelog to enable versioning; add most recent entries at the top. -->
       <revhistory xml:id="rh-kernel-boot-parameters-modify">
-        <revision><revnumber>1</revnumber><date>2023-11-28</date>
+        <revision><revnumber>1</revnumber><date>2024-11-28</date>
           <revdescription>
             <para>
               Initial version
@@ -95,8 +95,7 @@
         <productname version="15 SP6">&sles;</productname>
       </meta>
       <meta name="title" its:translate="yes">Modifying kernel boot parameters</meta>
-      <meta name="description" its:translate="yes">How to modify kernel boot parameters
-        parameters for customizing the boot process.</meta>
+      <meta name="description" its:translate="yes">How to modify kernel boot parameters for customizing the boot process.</meta>
       <meta name="social-descr" its:translate="yes">Modify kernel boot parameters</meta>
       <!-- suitable category, comma-separated list of categories -->
       <meta name="category" content="Systems Management" its:translate="no"/>
@@ -115,8 +114,8 @@
             <term>WHAT?</term>
             <listitem>
               <para>
-                Concepts, examples and modification process of kernel boot parameters for
-                customizing the boot process and the subsequent environment.
+                Concepts, examples and modification process of kernel boot parameters to
+                customize the boot process and the resulting environment.
               </para>
             </listitem>
           </varlistentry>
@@ -136,7 +135,7 @@
             <listitem>
               <para>
                 It 15 minutes to fully understand the concepts and the process, and 5 minutes to
-                modify kernel boot parameters and observe its effect after reboot.
+                modify kernel boot parameters and observe their effect after a reboot.
               </para>
             </listitem>
           </varlistentry>

--- a/concepts/kernel-boot-parameters-modify-difference-linuxrc-parameters.xml
+++ b/concepts/kernel-boot-parameters-modify-difference-linuxrc-parameters.xml
@@ -67,8 +67,8 @@
     <itemizedlist>
       <listitem>
         <para>
-          <literal>rd.driver.blacklist=</literal>: Specifies drivers to be blocked in the
-          initrd. For example, <literal>rd.driver.blacklist=nouveau</literal> prevents the
+          <literal>rd.driver.blacklist=</literal>: Specifies drivers to be blocked in the initrd.
+          For example, <literal>rd.driver.blacklist=nouveau</literal> prevents the
           <literal>nouveau</literal> graphics driver from loading during the early stages of boot.
           This can be useful when troubleshooting driver-related boot issues.
         </para>

--- a/concepts/kernel-boot-parameters-modify-difference-linuxrc-parameters.xml
+++ b/concepts/kernel-boot-parameters-modify-difference-linuxrc-parameters.xml
@@ -32,55 +32,75 @@
     </abstract>
   </info>
   <section xml:id="kernel-boot-parameters-modify-linuxrc-parameter-introduction">
-    <title>What are linuxrc parameters?</title>
+    <title>What are linuxrc parameters and why are they different from kernel boot parameters</title>
     <para>
-      In &productname;, the <literal>linuxrc</literal> is a script that runs during the boot
-      process before the systems's root file system is mounted, and serves as the initial RAM disk
-      (initrd) entry point. The <literal>linuxrc</literal> parameters are used within this script
-      to configure the system further before transitioning to the actual root file system.
+      In &sle;, the <literal>linuxrc</literal> script is executed during the boot process before
+      the system's root file system is mounted. It acts as the initial RAM disk (initrd) entry
+      point and sets up the environment needed for the kernel to load the root file system.
+      <literal>linuxrc</literal> parameters are used to pass configurations that affect this early
+      stage of the boot process, such as driver loading, debugging options, or hardware
+      initialization.
     </para>
     <para>
-      Similar to kernel boot parameters, you can pass linuxrc parameters either using the command
-      line, or using configuration files. The entries for linuxrc parameters are similar in
-      appearance to that of the kernel boot parameters.
+      In contrast, kernel boot parameters are passed to the kernel by the boot loader (such as
+      &grub;) after the initial RAM disk has handed control to the kernel. The kernel boot
+      parameters directly influence how the kernel operates and manages system features such as
+      power management, debugging and hardware interaction after the root file system is mounted.
     </para>
     <para>
-      However, the kernel boot parameters and the linuxrc parameters are different concepts. To
-      learn more about the linuxrc parameters, refer to
-      <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/appendix-linuxrc.html" os="sles"></link><link
-        xlink:href="https://en.opensuse.org/SDB:Linuxrc" os="non-sles"></link>.
+      The distinction is critical because <literal>linuxrc</literal> parameters are used to
+      configure the environment before the kernel fully initializes, whereas kernel boot parameters
+      control the behavior of the kernel after this point. Misinterpreting or interchanging the two
+      can lead to improper configurations and boot failures.
+    </para>
+    <para>
+      To learn more about the <literal>linuxrc</literal> parameters and their usage, refer to
+      <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/appendix-linuxrc.html"></link>.
     </para>
   </section>
   <section xml:id="kernel-boot-parameters-modify-linuxrc-parameter-examples">
     <title>Examples of linuxrc parameters</title>
     <para>
-      To highlight the similarity in appearance, observe the following examples:
+      The following examples highlight common <literal>linuxrc</literal> parameters and their use
+      cases to configure the environment before the kernel initializes:
     </para>
     <itemizedlist>
       <listitem>
         <para>
           <literal>rd.driver.blacklist=</literal>: Specifies drivers to be blacklisted in the
           initrd. For example, <literal>rd.driver.blacklist=nouveau</literal> prevents the
-          <literal>nouveau</literal> graphics driver from loading.
+          <literal>nouveau</literal> graphics driver from loading during the early stages of boot.
+          This can be useful when troubleshooting driver-related boot issues.
         </para>
       </listitem>
       <listitem>
         <para>
           <literal>rd.break</literal>: Interrupts the boot process and drops the system to a shell
-          for debugging purposes within the initrd.
+          within the initrd for debugging purposes. This parameter is helpful for diagnosing issues
+          related to the early boot process, such as driver loading or file system mounting errors.
         </para>
       </listitem>
       <listitem>
         <para>
           <literal>rd.retry=</literal>: Specifies the number of retries for device scanning in the
-          initrd. For example, <literal>rd.retry=3</literal>.
+          initrd. For example, <literal>rd.retry=3</literal> configures the system to retry
+          scanning devices three times before giving up, which can be critical for resolving
+          transient hardware initialization issues.
         </para>
       </listitem>
       <listitem>
         <para>
-          <literal>rd.luks=1</literal>: Activates support for encrypted devices in the initrd.
+          <literal>rd.luks=1</literal>: Enables support for encrypted devices in the initrd. This
+          parameter is essential for systems that use encrypted root file systems, ensuring that
+          decryption takes place during the initial boot stage.
         </para>
       </listitem>
     </itemizedlist>
+    <para>
+      By contrast, equivalent kernel boot parameters such as <literal>quiet</literal> or
+      <literal>nomodeset</literal> are not used in the initrd phase but take effect after the
+      kernel is fully initialized. This reinforces the need to distinguish between these two types
+      of parameters.
+    </para>
   </section>
 </topic>

--- a/concepts/kernel-boot-parameters-modify-difference-linuxrc-parameters.xml
+++ b/concepts/kernel-boot-parameters-modify-difference-linuxrc-parameters.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This file originates from the project https://github.com/openSUSE/doc-kit -->
+<!-- This file can be edited downstream. -->
+<!DOCTYPE topic
+[
+  <!ENTITY % entities SYSTEM "../common/generic-entities.ent">
+    %entities;
+]>
+<!-- refers to legacy doc: <add github link to legacy doc piece, if applicable> -->
+<!-- point back to this document with a similar comment added to your legacy doc piece -->
+<!-- refer to README.md for file and id naming conventions -->
+<!-- metadata is dealt with on the assembly level -->
+<topic xml:id="kernel-boot-parameters-modify-difference-linuxrc-parameters"
+ role="concept" xml:lang="en"
+ xmlns="http://docbook.org/ns/docbook" version="5.2"
+ xmlns:its="http://www.w3.org/2005/11/its"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink"
+ xmlns:trans="http://docbook.org/ns/transclusion">
+  <info>
+    <title>Difference between kernel boot parameters and linuxrc parameters</title>
+    <!-- can be changed via merge in the assembly -->
+    <!--add author's email address-->
+    <meta name="maintainer" content="ssarkar@suse.com" its:translate="no"/>
+    <abstract>
+      <!-- can be changed via merge in the assembly -->
+      <para>
+        Kernel boot parameters and linuxrc parameters are often similar in appearance, but
+        conceptually they are entirely different. It is important that you do not confuse them and
+        understand their basic difference.
+      </para>
+    </abstract>
+  </info>
+  <section xml:id="kernel-boot-parameters-modify-linuxrc-parameter-introduction">
+    <title>What are linuxrc parameters?</title>
+    <para>
+      In &productname;, the <literal>linuxrc</literal> is a script that runs during the boot
+      process before the systems's root file system is mounted, and serves as the initial RAM disk
+      (initrd) entry point. The <literal>linuxrc</literal> parameters are used within this script
+      to configure the system further before transitioning to the actual root file system.
+    </para>
+    <para>
+      Similar to kernel boot parameters, you can pass linuxrc parameters either using the command
+      line, or using configuration files. The entries for linuxrc parameters are similar in
+      appearance to that of the kernel boot parameters.
+    </para>
+    <para>
+      However, the kernel boot parameters and the linuxrc parameters are different concepts. To
+      learn more about the linuxrc parameters, refer to
+      <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/appendix-linuxrc.html" os="sles"></link><link
+        xlink:href="https://en.opensuse.org/SDB:Linuxrc" os="non-sles"></link>.
+    </para>
+  </section>
+  <section xml:id="kernel-boot-parameters-modify-linuxrc-parameter-examples">
+    <title>Examples of linuxrc parameters</title>
+    <para>
+      To highlight the similarity in appearance, observe the following examples:
+    </para>
+    <itemizedlist>
+      <listitem>
+        <para>
+          <literal>rd.driver.blacklist=</literal>: Specifies drivers to be blacklisted in the
+          initrd. For example, <literal>rd.driver.blacklist=nouveau</literal> prevents the
+          <literal>nouveau</literal> graphics driver from loading.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>rd.break</literal>: Interrupts the boot process and drops the system to a shell
+          for debugging purposes within the initrd.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>rd.retry=</literal>: Specifies the number of retries for device scanning in the
+          initrd. For example, <literal>rd.retry=3</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>rd.luks=1</literal>: Activates support for encrypted devices in the initrd.
+        </para>
+      </listitem>
+    </itemizedlist>
+  </section>
+</topic>

--- a/concepts/kernel-boot-parameters-modify-difference-linuxrc-parameters.xml
+++ b/concepts/kernel-boot-parameters-modify-difference-linuxrc-parameters.xml
@@ -32,7 +32,7 @@
     </abstract>
   </info>
   <section xml:id="kernel-boot-parameters-modify-linuxrc-parameter-introduction">
-    <title>What are linuxrc parameters and why are they different from kernel boot parameters</title>
+    <title>What are linuxrc parameters and why are they different from kernel boot parameters?</title>
     <para>
       In &sle;, the <literal>linuxrc</literal> script is executed during the boot process before
       the system's root file system is mounted. It acts as the initial RAM disk (initrd) entry
@@ -67,7 +67,7 @@
     <itemizedlist>
       <listitem>
         <para>
-          <literal>rd.driver.blacklist=</literal>: Specifies drivers to be blacklisted in the
+          <literal>rd.driver.blacklist=</literal>: Specifies drivers to be blocked in the
           initrd. For example, <literal>rd.driver.blacklist=nouveau</literal> prevents the
           <literal>nouveau</literal> graphics driver from loading during the early stages of boot.
           This can be useful when troubleshooting driver-related boot issues.
@@ -97,8 +97,8 @@
       </listitem>
     </itemizedlist>
     <para>
-      By contrast, equivalent kernel boot parameters such as <literal>quiet</literal> or
-      <literal>nomodeset</literal> are not used in the initrd phase but take effect after the
+      By contrast, equivalent kernel boot parameters such as <parameter>quiet</parameter> or
+      <parameter>nomodeset</parameter> are not used in the initrd phase but take effect after the
       kernel is fully initialized. This reinforces the need to distinguish between these two types
       of parameters.
     </para>

--- a/concepts/kernel-boot-parameters-modify-introduction.xml
+++ b/concepts/kernel-boot-parameters-modify-introduction.xml
@@ -26,7 +26,7 @@
       <!-- can be changed via merge in the assembly -->
       <para>
         Before modifying kernel boot parameters, it is important to understand the basic concepts -
-        definition, methods, benifits and examples of modifying kernel boot parameters.
+        definition, methods, benefits and examples of modifying kernel boot parameters.
       </para>
     </abstract>
   </info>
@@ -181,9 +181,9 @@
           <itemizedlist>
             <listitem>
               <para>
-                In the &yast;, navigate to <guimenu>System</guimenu>&gt;<guimenu>Boot
-                Loader</guimenu>&gt;<guimenu>Boot Loader Settings</guimenu>&gt;<guimenu>Kernel
-                Parameters</guimenu> enter parameters in the <guimenu>Optional Kernel Command Line
+                In &yast;, select <menuchoice><guimenu>System</guimenu><guimenu>Boot
+                Loader</guimenu><guimenu>Boot Loader Settings</guimenu><guimenu>Kernel
+                Parameters</guimenu></menuchoice>. Enter parameters in the <guimenu>Optional Kernel Command Line
                 Parameter</guimenu> field with spaces between them.
               </para>
             </listitem>
@@ -246,7 +246,7 @@
               </listitem>
             </varlistentry>
             <varlistentry>
-              <term>&grub; onfiguration File</term>
+              <term>&grub; configuration file</term>
               <listitem>
                 <para>
                   Use either double quotes with escape characters, or use backslashes.

--- a/concepts/kernel-boot-parameters-modify-introduction.xml
+++ b/concepts/kernel-boot-parameters-modify-introduction.xml
@@ -33,15 +33,27 @@
   <section xml:id="kernel-boot-parameters-modify-definition">
     <title>What are kernel boot parameters?</title>
     <para>
-      Kernel boot parameters are configurations passed to the &productname; kernel during the boot
-      process for &grub;, instructing it on how to configure certain features and make hem behave
-      in the intended manner.
+      Kernel boot parameters are configurations passed to the &productname; kernel during the boot process
+      for &grub;, instructing it on how to configure certain features and make them behave in the
+      intended manner. You can modify these configurations either temporarily or permanently,
+      depending on whether you want the changes to persist even after the next reboot.
+    </para>
+    <para>
+     If you want changes in the system to last only for the upcoming session session
+     after the boot, you can temporarily modify the kernel boot parameters. For more information,
+     see the section <xref linkend="kernel-boot-parameters-modify-temporary"></xref>.
+    </para>
+    <para>
+     However, if you want the
+     changes to persist till your next modification, you can permanently modify the kernel boot
+     parameters. For more information, see the section <xref
+     linkend="kernel-boot-parameters-modify-permanent"></xref>. You can make permanent changes
     </para>
   </section>
   <section xml:id="kernel-boot-parameters-modify-examples">
     <title>Examples of commonly modified kernel boot parameters</title>
     <para>
-      There are many different kernel parameters that you can optionally modify to customize your
+      There are several kernel parameters that you can optionally modify to customize your
       boot process. Based on you your use case, you can consider few of the most commonly modified
       kernel boot parameters:
     </para>

--- a/concepts/kernel-boot-parameters-modify-introduction.xml
+++ b/concepts/kernel-boot-parameters-modify-introduction.xml
@@ -25,8 +25,7 @@
     <abstract>
       <!-- can be changed via merge in the assembly -->
       <para>
-        Before modifying kernel boot parameters, it is important to understand the basic concepts -
-        definition, methods, benefits and examples of modifying kernel boot parameters.
+        Before modifying kernel boot parameters, it is important to understand the basic concepts: definition, methods, benefits and examples of modifying kernel boot parameters.
       </para>
     </abstract>
   </info>
@@ -37,7 +36,7 @@
       managed by the &grub;. The configurations are instructions to the &grub; boot loader on how
       to configure certain features and make them behave in the intended manner. The method of
       modification depends on whether you want the changes to impact only the next boot, or all
-      subsequent boots till further changes are made.
+      subsequent boots until further changes are made.
     </para>
   </section>
   <section xml:id="kernel-boot-parameters-modification-types">
@@ -111,8 +110,8 @@
           <title>Troubleshooting</title>
           <para>
             Altering parameters to troubleshoot issues such as graphics driver problems, ensuring a
-            more stable and functional system. For instance, the <code>nomodeset</code> parameter
-            can be used to disable kernel mode setting, which is helpful when troubleshooting
+            more stable and functional system. For instance, the <parameter>nomodeset</parameter> parameter
+            can disable kernel mode setting, which is helpful when troubleshooting
             issues with graphics drivers that prevent the system from booting.
           </para>
         </formalpara>
@@ -129,32 +128,32 @@
     <itemizedlist>
       <listitem>
         <para>
-          <literal>root=</literal>: Specifies the path to the root file system.
+          <parameter>root=</parameter>: Specifies the path to the root file system.
         </para>
       </listitem>
       <listitem>
         <para>
-          <literal>quiet</literal>: Suppresses most boot messages.
+          <parameter>quiet</parameter>: Suppresses most boot messages.
         </para>
       </listitem>
       <listitem>
         <para>
-          <literal>splash</literal>: Displays a graphical boot splash screen.
+          <parameter>splash</parameter>: Displays a graphical boot splash screen.
         </para>
       </listitem>
       <listitem>
         <para>
-          <literal>nomodeset</literal>: Disables kernel mode setting.
+          <parameter>nomodeset</parameter>: Disables kernel mode setting.
         </para>
       </listitem>
       <listitem>
         <para>
-          <literal>debug</literal>: Enables debugging output.
+          <parameter>debug</parameter>: Enables debugging output.
         </para>
       </listitem>
       <listitem>
         <para>
-          <literal>acpi=</literal>: Toggles the Advanced Configuration and Power Interface (ACPI)
+          <parameter>acpi=</parameter>: Toggles the Advanced Configuration and Power Interface (ACPI)
           settings.
         </para>
       </listitem>
@@ -198,7 +197,7 @@
             <listitem>
               <para>
                 At the boot menu, press <keycap>E</keycap> to edit, locate the line starting with
-                <literal>linux</literal> or <literal>linux16</literal>, and add parameters with
+                <literal>linux</literal>, and add parameters with
                 spaces.
               </para>
             </listitem>

--- a/concepts/kernel-boot-parameters-modify-introduction.xml
+++ b/concepts/kernel-boot-parameters-modify-introduction.xml
@@ -25,7 +25,8 @@
     <abstract>
       <!-- can be changed via merge in the assembly -->
       <para>
-        Before modifying kernel boot parameters, it is important to understand the basic concepts: definition, methods, benefits and examples of modifying kernel boot parameters.
+        Before modifying kernel boot parameters, it is important to understand the basic concepts:
+        definition, methods, benefits and examples of modifying kernel boot parameters.
       </para>
     </abstract>
   </info>
@@ -110,9 +111,9 @@
           <title>Troubleshooting</title>
           <para>
             Altering parameters to troubleshoot issues such as graphics driver problems, ensuring a
-            more stable and functional system. For instance, the <parameter>nomodeset</parameter> parameter
-            can disable kernel mode setting, which is helpful when troubleshooting
-            issues with graphics drivers that prevent the system from booting.
+            more stable and functional system. For instance, the <parameter>nomodeset</parameter>
+            parameter can disable kernel mode setting, which is helpful when troubleshooting issues
+            with graphics drivers that prevent the system from booting.
           </para>
         </formalpara>
       </listitem>
@@ -122,8 +123,8 @@
     <title>Examples of commonly modified kernel boot parameters</title>
     <para>
       There are several kernel parameters that you can optionally modify to customize your boot
-      process. Based on you your use case, you can consider few of the most commonly modified
-      kernel boot parameters:
+      process. Based on your use case, you can consider a few of the most commonly modified kernel
+      boot parameters:
     </para>
     <itemizedlist>
       <listitem>
@@ -153,8 +154,8 @@
       </listitem>
       <listitem>
         <para>
-          <parameter>acpi=</parameter>: Toggles the Advanced Configuration and Power Interface (ACPI)
-          settings.
+          <parameter>acpi=</parameter>: Toggles the Advanced Configuration and Power Interface
+          (ACPI) settings.
         </para>
       </listitem>
     </itemizedlist>
@@ -182,8 +183,8 @@
               <para>
                 In &yast;, select <menuchoice><guimenu>System</guimenu><guimenu>Boot
                 Loader</guimenu><guimenu>Boot Loader Settings</guimenu><guimenu>Kernel
-                Parameters</guimenu></menuchoice>. Enter parameters in the <guimenu>Optional Kernel Command Line
-                Parameter</guimenu> field with spaces between them.
+                Parameters</guimenu></menuchoice>. Enter parameters in the <guimenu>Optional Kernel
+                Command Line Parameter</guimenu> field with spaces between them.
               </para>
             </listitem>
             <listitem>
@@ -197,8 +198,7 @@
             <listitem>
               <para>
                 At the boot menu, press <keycap>E</keycap> to edit, locate the line starting with
-                <literal>linux</literal>, and add parameters with
-                spaces.
+                <literal>linux</literal>, and add parameters with spaces.
               </para>
             </listitem>
           </itemizedlist>

--- a/concepts/kernel-boot-parameters-modify-introduction.xml
+++ b/concepts/kernel-boot-parameters-modify-introduction.xml
@@ -36,18 +36,10 @@
       Kernel boot parameters are configurations passed to the &productname; kernel during the boot process
       for &grub;, instructing it on how to configure certain features and make them behave in the
       intended manner. You can modify these configurations either temporarily or permanently,
-      depending on whether you want the changes to persist even after the next reboot.
+      depending on whether you want the changes to persist subsequent boots.
     </para>
     <para>
-     If you want changes in the system to last only for the upcoming session session
-     after the boot, you can temporarily modify the kernel boot parameters. For more information,
-     see the section <xref linkend="kernel-boot-parameters-modify-temporary"></xref>.
-    </para>
-    <para>
-     However, if you want the
-     changes to persist till your next modification, you can permanently modify the kernel boot
-     parameters. For more information, see the section <xref
-     linkend="kernel-boot-parameters-modify-permanent"></xref>. You can make permanent changes
+
     </para>
   </section>
   <section xml:id="kernel-boot-parameters-modify-examples">

--- a/concepts/kernel-boot-parameters-modify-introduction.xml
+++ b/concepts/kernel-boot-parameters-modify-introduction.xml
@@ -26,27 +26,104 @@
       <!-- can be changed via merge in the assembly -->
       <para>
         Before modifying kernel boot parameters, it is important to understand the basic concepts -
-        definition, examples and reasons for modifying kernel boot parameters.
+        definition, methods, benifits and examples of modifying kernel boot parameters.
       </para>
     </abstract>
   </info>
   <section xml:id="kernel-boot-parameters-modify-definition">
     <title>What are kernel boot parameters?</title>
     <para>
-      Kernel boot parameters are configurations passed to the &productname; kernel during the boot process
-      for &grub;, instructing it on how to configure certain features and make them behave in the
-      intended manner. You can modify these configurations either temporarily or permanently,
-      depending on whether you want the changes to persist subsequent boots.
+      Kernel boot parameters are configurations passed to the &sle; kernel during the boot process
+      managed by the &grub;. The configurations are instructions to the &grub; boot loader on how
+      to configure certain features and make them behave in the intended manner. The method of
+      modification depends on whether you want the changes to impact only the next boot, or all
+      subsequent boots till further changes are made.
     </para>
+  </section>
+  <section xml:id="kernel-boot-parameters-modification-types">
+    <title>Methods of modification</title>
     <para>
-
+      You can modify the kernel boot parameters using the following methods:
     </para>
+    <variablelist>
+      <varlistentry>
+        <term>Temporarily</term>
+        <listitem>
+          <para>
+            Changes are held in memory and apply only to the upcoming boot process. These changes
+            made through the &grub; boot menu are not written to any configuration file and are
+            discarded after reboot.
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>Permanently</term>
+        <listitem>
+          <para>
+            Changes are written to <filename>/etc/default/grub</filename> file and persist across
+            all subsequent boot processes. For permanent changes, we
+            <emphasis role="strong">recommend</emphasis> using the &yastcc; instead of directly
+            editing the <filename>/etc/default/grub</filename> file.
+          </para>
+          <para>
+            However, if you directly edit the <filename>/etc/default/grub</filename> file, modify
+            the <varname>GRUB_CMDLINE_LINUX</varname> or
+            <varname>GRUB_CMDLINE_LINUX_DEFAULT</varname> variables. After modification, regenerate
+            the &grub; configuration by running the following command with administrative
+            privileges.
+          </para>
+<screen>&prompt.sudo;<command>grub2-mkconfig -o /boot/grub2/grub.cfg</command></screen>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+  </section>
+  <section xml:id="kernel-boot-parameters-modify-reason">
+    <title>Benefits of modifying kernel boot parameters</title>
+    <para>
+      Modifying kernel boot parameters is essential for achieving specific system configurations
+      and addressing several scenarios, including:
+    </para>
+    <itemizedlist>
+      <listitem>
+        <formalpara>
+          <title>Performance optimization</title>
+          <para>
+            Tweaking parameters to enhance system performance, responsiveness, and overall
+            efficiency based on specific system requirements. For example, using the
+            <code>quiet</code> parameter suppresses most boot messages, reducing boot time and
+            improving performance during startup.
+          </para>
+        </formalpara>
+      </listitem>
+      <listitem>
+        <formalpara>
+          <title>Hardware compatibility</title>
+          <para>
+            Tailoring parameters to ensure compatibility with specific hardware components,
+            addressing potential compatibility issues. For example, the <code>acpi=off</code>
+            parameter can be used to disable the Advanced Configuration and Power Interface (ACPI)
+            to resolve boot problems on older hardware.
+          </para>
+        </formalpara>
+      </listitem>
+      <listitem>
+        <formalpara>
+          <title>Troubleshooting</title>
+          <para>
+            Altering parameters to troubleshoot issues such as graphics driver problems, ensuring a
+            more stable and functional system. For instance, the <code>nomodeset</code> parameter
+            can be used to disable kernel mode setting, which is helpful when troubleshooting
+            issues with graphics drivers that prevent the system from booting.
+          </para>
+        </formalpara>
+      </listitem>
+    </itemizedlist>
   </section>
   <section xml:id="kernel-boot-parameters-modify-examples">
     <title>Examples of commonly modified kernel boot parameters</title>
     <para>
-      There are several kernel parameters that you can optionally modify to customize your
-      boot process. Based on you your use case, you can consider few of the most commonly modified
+      There are several kernel parameters that you can optionally modify to customize your boot
+      process. Based on you your use case, you can consider few of the most commonly modified
       kernel boot parameters:
     </para>
     <itemizedlist>
@@ -83,44 +160,132 @@
       </listitem>
     </itemizedlist>
     <para>
-      Source documentation for kernel parameters is available at
-      <link xlink:href="https://www.kernel.org/doc/Documentation/admin-guide/kernel-parameters.txt"/>
+      For a detailed understanding of all available kernel parameters and their possible values,
+      source documentation is available at
+      <link
+      xlink:href="https://www.kernel.org/doc/Documentation/admin-guide/kernel-parameters.txt"/>.
     </para>
   </section>
-  <section xml:id="kernel-boot-parameters-modify-reason">
-    <title>Benefits of modifying kernel boot parameters</title>
+  <section xml:id="kernel-boot-parameters-modify-general-rules">
+    <title>General rules for specifying values of kernel boot parameters</title>
     <para>
-      Modifying kernel boot parameters is essential for achieving specific system configurations
-      and addressing several scenarios, including:
+      When modifying kernel boot parameters, follow these essential formatting rules:
     </para>
-    <itemizedlist>
-      <listitem>
-        <formalpara>
-          <title>Performance optimization</title>
+    <variablelist>
+      <varlistentry>
+        <term>Basic Parameter Spacing</term>
+        <listitem>
           <para>
-            Tweaking parameters to enhance system performance, responsiveness, and overall
-            efficiency based on specific system requirements.
+            Separate individual parameters with a single space:
           </para>
-        </formalpara>
-      </listitem>
-      <listitem>
-        <formalpara>
-          <title>Hardware compatibility</title>
+          <itemizedlist>
+            <listitem>
+              <para>
+                In the &yast;, navigate to <guimenu>System</guimenu>&gt;<guimenu>Boot
+                Loader</guimenu>&gt;<guimenu>Boot Loader Settings</guimenu>&gt;<guimenu>Kernel
+                Parameters</guimenu> enter parameters in the <guimenu>Optional Kernel Command Line
+                Parameter</guimenu> field with spaces between them.
+              </para>
+            </listitem>
+            <listitem>
+              <para>
+                In the <filename>/etc/default/grub</filename> configuration file for &grub;, use
+                spaces between kernel parameters when passing them as string values to the
+                <varname>GRUB_CMDLINE_LINUX</varname> or
+                <varname>GRUB_CMDLINE_LINUX_DEFAULT</varname> variables.
+              </para>
+            </listitem>
+            <listitem>
+              <para>
+                At the boot menu, press <keycap>E</keycap> to edit, locate the line starting with
+                <literal>linux</literal> or <literal>linux16</literal>, and add parameters with
+                spaces.
+              </para>
+            </listitem>
+          </itemizedlist>
+          <example>
+            <title>Separate individual parameters with a single space</title>
+<screen>root=/dev/sda1 quiet splash</screen>
+          </example>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>Parameter Value Assignment</term>
+        <listitem>
           <para>
-            Tailoring parameters to ensure compatibility with specific hardware components,
-            addressing potential compatibility issues.
+            When assigning values, use the equals sign (<literal>=</literal>) without spaces:
           </para>
-        </formalpara>
-      </listitem>
-      <listitem>
-        <formalpara>
-          <title>Troubleshooting</title>
+          <example>
+            <title>Correct method of assigning values to kernel parameters</title>
+<screen>root=/dev/sda1 video=1920x1080</screen>
+          </example>
+          <example>
+            <title>Incorrect method of assigning values to kernel parameters</title>
+<screen>root = /dev/sda1 video = 1920x1080</screen>
+          </example>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>Values Containing Spaces</term>
+        <listitem>
           <para>
-            Altering parameters to troubleshoot issues such as graphics driver problems, ensuring a
-            more stable and functional system.
+            For values containing spaces, the handling differs between methods:
           </para>
-        </formalpara>
-      </listitem>
-    </itemizedlist>
+          <variablelist>
+            <varlistentry>
+              <term>&yastcc; Boot Loader</term>
+              <listitem>
+                <para>
+                  Enter the value with quotes directly in the parameter field; the &yastcc; handles
+                  the spacing appropriately before passing it on to &grub;.
+                </para>
+                <example>
+                  <title>Kernel parameter values containing spaces in the &yastcc;</title>
+<screen>root="/dev/mapper/<replaceable>USER VOLUME</replaceable>"</screen>
+                </example>
+              </listitem>
+            </varlistentry>
+            <varlistentry>
+              <term>&grub; onfiguration File</term>
+              <listitem>
+                <para>
+                  Use either double quotes with escape characters, or use backslashes.
+                </para>
+                <example>
+                  <title>Kernel parameter values containing spaces in the &grub; configuration file</title>
+<screen>GRUB_CMDLINE_LINUX="root=\"/dev/mapper/<replaceable>USER VOLUME</replaceable>\""</screen>
+<screen>GRUB_CMDLINE_LINUX="root=/dev/mapper/<replaceable>USER<emphasis>\</emphasis> VOLUME</replaceable>"</screen>
+                </example>
+              </listitem>
+            </varlistentry>
+            <varlistentry>
+              <term>&grub; Boot Menu</term>
+              <listitem>
+                <para>
+                  Use only double quotes for values containing spaces:
+                </para>
+                <example>
+                  <title>Kernel parameter values containing spaces in the &grub; boot menu</title>
+<screen>root="/dev/mapper/<replaceable>USER VOLUME</replaceable>"</screen>
+                </example>
+              </listitem>
+            </varlistentry>
+          </variablelist>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>Multiple values for a kernel parameter</term>
+        <listitem>
+          <para>
+            Use commas without spaces to separate multiple values for a single parameter in all
+            methods:
+          </para>
+          <example>
+            <title>Multiple values for a kernel parameter</title>
+<screen>console=tty0,tty1 video=HDMI-A-1:1920x1080@60,VGA-1:1024x768</screen>
+          </example>
+        </listitem>
+      </varlistentry>
+    </variablelist>
   </section>
 </topic>

--- a/concepts/kernel-boot-parameters-modify-introduction.xml
+++ b/concepts/kernel-boot-parameters-modify-introduction.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This file originates from the project https://github.com/openSUSE/doc-kit -->
+<!-- This file can be edited downstream. -->
+<!DOCTYPE topic
+[
+  <!ENTITY % entities SYSTEM "../common/generic-entities.ent">
+    %entities;
+]>
+<!-- refers to legacy doc: <add github link to legacy doc piece, if applicable> -->
+<!-- point back to this document with a similar comment added to your legacy doc piece -->
+<!-- refer to README.md for file and id naming conventions -->
+<!-- metadata is dealt with on the assembly level -->
+<topic xml:id="kernel-boot-parameters-modify-introduction"
+ role="concept" xml:lang="en"
+ xmlns="http://docbook.org/ns/docbook" version="5.2"
+ xmlns:its="http://www.w3.org/2005/11/its"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink"
+ xmlns:trans="http://docbook.org/ns/transclusion">
+  <info>
+    <title>Introduction to kernel boot parameters</title>
+    <!-- can be changed via merge in the assembly -->
+    <!--add author's email address-->
+    <meta name="maintainer" content="ssarkar@suse.com" its:translate="no"/>
+    <abstract>
+      <!-- can be changed via merge in the assembly -->
+      <para>
+        Before modifying kernel boot parameters, it is important to understand the basic concepts -
+        definition, examples and reasons for modifying kernel boot parameters.
+      </para>
+    </abstract>
+  </info>
+  <section xml:id="kernel-boot-parameters-modify-definition">
+    <title>What are kernel boot parameters?</title>
+    <para>
+      Kernel boot parameters are configurations passed to the &productname; kernel during the boot
+      process for &grub;, instructing it on how to configure certain features and make hem behave
+      in the intended manner.
+    </para>
+  </section>
+  <section xml:id="kernel-boot-parameters-modify-examples">
+    <title>Examples of commonly modified kernel boot parameters</title>
+    <para>
+      There are many different kernel parameters that you can optionally modify to customize your
+      boot process. Based on you your use case, you can consider few of the most commonly modified
+      kernel boot parameters:
+    </para>
+    <itemizedlist>
+      <listitem>
+        <para>
+          <literal>root=</literal>: Specifies the path to the root file system.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>quiet</literal>: Suppresses most boot messages.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>splash</literal>: Displays a graphical boot splash screen.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>nomodeset</literal>: Disables kernel mode setting.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>debug</literal>: Enables debugging output.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>acpi=</literal>: Toggles the Advanced Configuration and Power Interface (ACPI)
+          settings.
+        </para>
+      </listitem>
+    </itemizedlist>
+    <para>
+      Source documentation for kernel parameters is available at
+      <link xlink:href="https://www.kernel.org/doc/Documentation/admin-guide/kernel-parameters.txt"/>
+    </para>
+  </section>
+  <section xml:id="kernel-boot-parameters-modify-reason">
+    <title>Benefits of modifying kernel boot parameters</title>
+    <para>
+      Modifying kernel boot parameters is essential for achieving specific system configurations
+      and addressing several scenarios, including:
+    </para>
+    <itemizedlist>
+      <listitem>
+        <formalpara>
+          <title>Performance optimization</title>
+          <para>
+            Tweaking parameters to enhance system performance, responsiveness, and overall
+            efficiency based on specific system requirements.
+          </para>
+        </formalpara>
+      </listitem>
+      <listitem>
+        <formalpara>
+          <title>Hardware compatibility</title>
+          <para>
+            Tailoring parameters to ensure compatibility with specific hardware components,
+            addressing potential compatibility issues.
+          </para>
+        </formalpara>
+      </listitem>
+      <listitem>
+        <formalpara>
+          <title>Troubleshooting</title>
+          <para>
+            Altering parameters to troubleshoot issues such as graphics driver problems, ensuring a
+            more stable and functional system.
+          </para>
+        </formalpara>
+      </listitem>
+    </itemizedlist>
+  </section>
+</topic>

--- a/glues/kernel-boot-parameters-modify-more-info.xml
+++ b/glues/kernel-boot-parameters-modify-more-info.xml
@@ -34,7 +34,7 @@
     </listitem>
     <listitem>
       <para>
-        Detailed information of boot parameters for &sle; is available at
+        Detailed information about boot parameters for &sle; is available at
         <link
        xlink:href="https://documentation.suse.com/sles/html/SLES-all/cha-boot-parameters.html"
        ></link>.

--- a/glues/kernel-boot-parameters-modify-more-info.xml
+++ b/glues/kernel-boot-parameters-modify-more-info.xml
@@ -25,8 +25,8 @@
   <itemizedlist>
     <listitem>
       <para>
-        Detailed information about the parameters in the &grub; configuration file for
-        &productname; is available at
+        Detailed information about the parameters in the &grub; configuration file for &sle; is
+        available at
         <link
        xlink:href="https://documentation.suse.com/sles/html/SLES-all/cha-grub2.html#sec-grub2-etc-default-grub"
        ></link>.
@@ -34,7 +34,7 @@
     </listitem>
     <listitem>
       <para>
-        Detailed information of boot parameters for &productname; is available at
+        Detailed information of boot parameters for &sle; is available at
         <link
        xlink:href="https://documentation.suse.com/sles/html/SLES-all/cha-boot-parameters.html"
        ></link>.

--- a/glues/kernel-boot-parameters-modify-more-info.xml
+++ b/glues/kernel-boot-parameters-modify-more-info.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This file originates from the project https://github.com/openSUSE/doc-kit -->
+<!-- This file can be edited downstream. -->
+<!DOCTYPE topic
+[
+  <!ENTITY % entities SYSTEM "../common/generic-entities.ent">
+    %entities;
+]>
+<topic xml:id="kernel-boot-parameters-modify-more-info"
+ role="glue" xml:lang="en"
+ xmlns="http://docbook.org/ns/docbook" version="5.2"
+ xmlns:its="http://www.w3.org/2005/11/its"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink"
+ xmlns:trans="http://docbook.org/ns/transclusion">
+  <info>
+    <title>For more information</title>
+    <!-- can be changed via merge in the
+      assembly -->
+    <!--add author's e-mail address-->
+    <meta name="maintainer" content="ssarkar@suse.com" its:translate="no"/>
+    <!-- add an abstract/para here, if you need one -->
+    <!-- can be changed via merge in the assembly -->
+  </info>
+  <itemizedlist>
+    <listitem>
+      <para>
+        Detailed information about the parameters in the &grub; configuration file for
+        &productname; is available at
+        <link
+       xlink:href="https://documentation.suse.com/sles/html/SLES-all/cha-grub2.html#sec-grub2-etc-default-grub"
+       ></link>.
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        Detailed information of boot parameters for &productname; is available at
+        <link
+       xlink:href="https://documentation.suse.com/sles/html/SLES-all/cha-boot-parameters.html"
+       ></link>.
+      </para>
+    </listitem>
+  </itemizedlist>
+</topic>

--- a/tasks/kernel-boot-parameters-modify-permanent.xml
+++ b/tasks/kernel-boot-parameters-modify-permanent.xml
@@ -51,7 +51,7 @@
       <step>
         <para>
           Log in to your system as root, or switch to a user with equivalent administrative
-          priviliges after logging in to your system.
+          privileges after logging in to your system.
         </para>
       </step>
       <step>
@@ -60,8 +60,7 @@
         </para>
 <screen>&prompt.root;<command>yast bootloader</command></screen>
         <para>
-          Alternatively, open the &yastcc; application and navigate to <guimenu>System</guimenu>
-          &gt; <guimenu>Boot Loader</guimenu>.
+          Alternatively, open the &yastcc; application and select <menuchoice><guimenu>System</guimenu><guimenu>Boot Loader</guimenu></menuchoice>.
         </para>
       </step>
       <step>

--- a/tasks/kernel-boot-parameters-modify-permanent.xml
+++ b/tasks/kernel-boot-parameters-modify-permanent.xml
@@ -27,39 +27,26 @@
       <!-- can be changed via merge in the assembly -->
       <para>
         To change kernel boot parameters persistently for all subsequent boot processes, edit the
-        kernel parameters using &yastcc;.
+        kernel parameters using &yastcc; as <literal>root</literal> or an user with equivalent
+        administrative privileges.
       </para>
     </abstract>
   </info>
-  <section xml:id="kernel-boot-parameters-modify-permanent-introduction">
-    <title>Introduction</title>
-    <para>
-      Permanent or persistent changes are helpful if a change needs to be applied for all
-      subsequent boot processes. Your changes are applied to all subsequent boot processes, unless
-      modified further.
-    </para>
-  </section>
-  <section xml:id="kernel-boot-parameters-modify-permanent-requirements">
-    <title>Requirements</title>
-    <para>
-      To change kernel boot parameters for all subsequent boot processes, you should have
-      <literal>root</literal> or equivalent administrative privileges.
-    </para>
-  </section>
-  <section xml:id="kernel-boot-parameters-modify-permanent-procedure">
+  <example>
     <title>Permanently modify kernel boot parameters using &yastcc;</title>
     <para>
       As an example of modifying kernel boot parameters persistently for all subsequent boot
       process, we disable the splash screen that you can see during the boot.
     </para>
-    <tip>
+    <warning>
       <para>
-        Before modifying kernel boot parameters, create a copy of the existing stable configuration
-        somewhere outside of your system. If the boat loader gets corrupted and your system fails
-        to boot, or you face problems after booting your system, the back up helps you compare and
-        restore the parameters to the last known working configuration.
+        Before modifying kernel boot parameters, create a copy of the existing stable &grub;
+        configuration (<filename>/etc/default/grub</filename>) somewhere outside of your system. If
+        the boat loader gets corrupted and your system fails to boot, or you face problems after
+        booting your system, the back up helps you compare and restore the parameters to the last
+        known working configuration.
       </para>
-    </tip>
+    </warning>
     <procedure>
       <step>
         <para>
@@ -99,13 +86,20 @@
         </para>
       </step>
     </procedure>
-  </section>
-  <section xml:id="kernel-boot-parameters-modify-permanent-summary">
-    <title>Summary</title>
     <para>
-      After executing the procedure and rebooting the system, you will not observe any splash
-      screen for all subsequent boot process unless the kernel parameter configurartion is modified
-      again.
+      After executing the procedure and rebooting the system, we do not observe any splash
+      screen for all subsequent boot process.
     </para>
-  </section>
+    <note>
+     <title>Editing the &grub; configuration file</title>
+      <para>
+       If you directly edit the <filename>/etc/default/grub</filename> file, modify
+       the <varname>GRUB_CMDLINE_LINUX</varname> or
+       <varname>GRUB_CMDLINE_LINUX_DEFAULT</varname> variables. After modification, regenerate
+       the &grub; configuration by running the following command with administrative
+       privileges.
+     </para>
+<screen>&prompt.sudo;<command>grub2-mkconfig -o /boot/grub2/grub.cfg</command></screen>
+    </note>
+  </example>
 </topic>

--- a/tasks/kernel-boot-parameters-modify-permanent.xml
+++ b/tasks/kernel-boot-parameters-modify-permanent.xml
@@ -27,7 +27,7 @@
       <!-- can be changed via merge in the assembly -->
       <para>
         To change kernel boot parameters persistently for all subsequent boot processes, edit the
-        kernel parameters using &yastcc; as <literal>root</literal> or an user with equivalent
+        kernel parameters using &yastcc; as <literal>root</literal> or a user with equivalent
         administrative privileges.
       </para>
     </abstract>
@@ -36,14 +36,14 @@
     <title>Permanently modify kernel boot parameters using &yastcc;</title>
     <para>
       As an example of modifying kernel boot parameters persistently for all subsequent boot
-      process, we disable the splash screen that you can see during the boot.
+      processes, we disable the splash screen that you can see during the boot.
     </para>
     <warning>
       <para>
         Before modifying kernel boot parameters, create a copy of the existing stable &grub;
         configuration (<filename>/etc/default/grub</filename>) somewhere outside of your system. If
         the boat loader gets corrupted and your system fails to boot, or you face problems after
-        booting your system, the back up helps you compare and restore the parameters to the last
+        booting your system, the backup helps you compare and restore the parameters to the last
         known working configuration.
       </para>
     </warning>
@@ -70,8 +70,8 @@
         </para>
 <screen><emphasis role="strong">splash=silent</emphasis> resume=/dev/disk/by-uuid/69ff0e54-23a7-4ba8-8983-5a29c54ffa5e  quiet security=apparmor crashkernel=301M,high crashkernel=72M,low</screen>
         <para>
-          As you can see, the string <literal>splash=silent</literal> is printed. Remove
-          <literal>splash=silent</literal> from the string.
+          As you can see, the string <parameter>splash=silent</parameter> is printed. Remove
+          <parameter>splash=silent</parameter> from the string.
         </para>
       </step>
       <step>
@@ -87,7 +87,7 @@
     </procedure>
     <para>
       After executing the procedure and rebooting the system, we do not observe any splash
-      screen for all subsequent boot process.
+      screen for all subsequent boot processes.
     </para>
     <note>
      <title>Editing the &grub; configuration file</title>

--- a/tasks/kernel-boot-parameters-modify-permanent.xml
+++ b/tasks/kernel-boot-parameters-modify-permanent.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This file originates from the project https://github.com/openSUSE/doc-kit -->
+<!-- This file can be edited downstream. -->
+<!DOCTYPE topic
+[
+  <!ENTITY % entities SYSTEM "../common/generic-entities.ent">
+    %entities;
+]>
+<!-- refers to legacy doc: <add github link to legacy doc piece, if applicable> -->
+<!-- point back to this document with a similar comment added to your legacy doc piece -->
+<!-- refer to README.md for file and id naming conventions -->
+<!-- metadata is dealt with on the assembly level -->
+<topic xml:id="kernel-boot-parameters-modify-permanent"
+ role="task" xml:lang="en"
+ xmlns="http://docbook.org/ns/docbook" version="5.2"
+ xmlns:its="http://www.w3.org/2005/11/its"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink"
+ xmlns:trans="http://docbook.org/ns/transclusion">
+  <info>
+    <title>Permanently modifying kernel boot parameters</title>
+    <!-- can be changed via merge
+      in the assembly -->
+    <!-- add author's e-mail -->
+    <meta name="maintainer" content="ssarkar@suse.com" its:translate="no"/>
+    <abstract>
+      <!-- can be changed via merge in the assembly -->
+      <para>
+        To change kernel boot parameters persistently for all subsequent boot processes, edit the
+        kernel parameters using &yastcc;.
+      </para>
+    </abstract>
+  </info>
+  <section xml:id="kernel-boot-parameters-modify-permanent-introduction">
+    <title>Introduction</title>
+    <para>
+      Permanent or persistent changes are helpful if a change needs to be applied for all
+      subsequent boot processes. Your changes are applied to all subsequent boot processes, unless
+      modified further.
+    </para>
+  </section>
+  <section xml:id="kernel-boot-parameters-modify-permanent-requirements">
+    <title>Requirements</title>
+    <para>
+      To change kernel boot parameters for all subsequent boot processes, you should have
+      <literal>root</literal> or equivalent administrative privileges.
+    </para>
+  </section>
+  <section xml:id="kernel-boot-parameters-modify-permanent-procedure">
+    <title>Permanently modify kernel boot parameters using &yastcc;</title>
+    <para>
+      As an example of modifying kernel boot parameters persistently for all subsequent boot
+      process, we disable the splash screen that you can see during the boot.
+    </para>
+    <tip>
+      <para>
+        Before modifying kernel boot parameters, create a copy of the existing stable configuration
+        somewhere outside of your system. If the boat loader gets corrupted and your system fails
+        to boot, or you face problems after booting your system, the back up helps you compare and
+        restore the parameters to the last known working configuration.
+      </para>
+    </tip>
+    <procedure>
+      <step>
+        <para>
+          Log in to your system as root, or switch to a user with equivalent administrative
+          priviliges after logging in to your system.
+        </para>
+      </step>
+      <step>
+        <para>
+          In your running system, open a root shell and run the following command:
+        </para>
+<screen>&prompt.root;<command>yast bootloader</command></screen>
+        <para>
+          Alternatively, open the &yastcc; application and navigate to <guimenu>System</guimenu>
+          &gt; <guimenu>Boot Loader</guimenu>.
+        </para>
+      </step>
+      <step>
+        <para>
+          Under the <guimenu>Kernel Parameters</guimenu> tab, edit the string for the
+          <guimenu>Optional Kernel Command Line Parameter</guimenu> field.
+        </para>
+<screen><emphasis role="strong">splash=silent</emphasis> resume=/dev/disk/by-uuid/69ff0e54-23a7-4ba8-8983-5a29c54ffa5e  quiet security=apparmor crashkernel=301M,high crashkernel=72M,low</screen>
+        <para>
+          As you can see, the string <literal>splash=silent</literal> is printed. Remove
+          <literal>splash=silent</literal> from the string.
+        </para>
+      </step>
+      <step>
+        <para>
+          Select <guimenu>OK</guimenu> to save the boot loader configuration.
+        </para>
+      </step>
+      <step>
+        <para>
+          Reboot. You should see that the splash screen does not appear.
+        </para>
+      </step>
+    </procedure>
+  </section>
+  <section xml:id="kernel-boot-parameters-modify-permanent-summary">
+    <title>Summary</title>
+    <para>
+      After executing the procedure and rebooting the system, you will not observe any splash
+      screen for all subsequent boot process unless the kernel parameter configurartion is modified
+      again.
+    </para>
+  </section>
+</topic>

--- a/tasks/kernel-boot-parameters-modify-permanent.xml
+++ b/tasks/kernel-boot-parameters-modify-permanent.xml
@@ -60,7 +60,8 @@
         </para>
 <screen>&prompt.root;<command>yast bootloader</command></screen>
         <para>
-          Alternatively, open the &yastcc; application and select <menuchoice><guimenu>System</guimenu><guimenu>Boot Loader</guimenu></menuchoice>.
+          Alternatively, open the &yastcc; application and select
+          <menuchoice><guimenu>System</guimenu><guimenu>Boot Loader</guimenu></menuchoice>.
         </para>
       </step>
       <step>
@@ -86,18 +87,17 @@
       </step>
     </procedure>
     <para>
-      After executing the procedure and rebooting the system, we do not observe any splash
-      screen for all subsequent boot processes.
+      After executing the procedure and rebooting the system, we do not observe any splash screen
+      for all subsequent boot processes.
     </para>
     <note>
-     <title>Editing the &grub; configuration file</title>
+      <title>Editing the &grub; configuration file</title>
       <para>
-       If you directly edit the <filename>/etc/default/grub</filename> file, modify
-       the <varname>GRUB_CMDLINE_LINUX</varname> or
-       <varname>GRUB_CMDLINE_LINUX_DEFAULT</varname> variables. After modification, regenerate
-       the &grub; configuration by running the following command with administrative
-       privileges.
-     </para>
+        If you directly edit the <filename>/etc/default/grub</filename> file, modify the
+        <varname>GRUB_CMDLINE_LINUX</varname> or <varname>GRUB_CMDLINE_LINUX_DEFAULT</varname>
+        variables. After modification, regenerate the &grub; configuration by running the following
+        command with administrative privileges.
+      </para>
 <screen>&prompt.sudo;<command>grub2-mkconfig -o /boot/grub2/grub.cfg</command></screen>
     </note>
   </example>

--- a/tasks/kernel-boot-parameters-modify-temporary.xml
+++ b/tasks/kernel-boot-parameters-modify-temporary.xml
@@ -27,39 +27,18 @@
       <!-- can be changed via merge in the assembly -->
       <para>
         To change kernel boot parameters on an experimental basis only for the upcoming boot
-        process, edit the options available on the &grub; boot screen.
+        process, edit the options available on the &grub; boot screen. Such changes are applied
+        only to the upcoming boot process and the resulting session; the changes do not persist
+        after reboot.
       </para>
     </abstract>
   </info>
-  <section xml:id="kernel-boot-parameters-modify-temporary-introduction">
-    <title>Introduction</title>
-    <para>
-      Temporary changes are helpful to debug or test the effect of modifying kernel boot
-      parameters. After you have changed the kernel boot parameters, the changes are applied for
-      the upcoming boot process. However, it does not survive subsequent boot processes.
-    </para>
-  </section>
-  <section xml:id="kernel-boot-parameters-modify-temporary-requirements">
-    <title>Requirements</title>
-    <para>
-      To modify kernel boot parameters only for the upcoming boot process, there are no strict
-      requirements. However, you must know the parameters you want to modify and their effect.
-    </para>
-  </section>
-  <section xml:id="kernel-boot-parameters-modify-temporary-procedure">
+  <example>
     <title>Temporarily modify kernel boot parameters using the &grub; boot menu</title>
     <para>
       As an example of modifying kernel boot parameters for the upcoming boot process, we disable
       the splash screen that you can see during the boot.
     </para>
-    <tip>
-      <para>
-        Before modifying kernel boot parameters, create a copy of the existing stable configuration
-        somewhere outside of your system. If the boat loader gets corrupted and your system fails
-        to boot, or you face problems after booting your system, the back up helps you compare and
-        restore the parameters to the last known working configuration.
-      </para>
-    </tip>
     <procedure>
       <step>
         <para>
@@ -78,9 +57,9 @@
           selected boot entry. It looks similiar to the following:
         </para>
 <screen>setparams '&productname; &productnumber;'
- ...
- ...
- echo 'Loading Linux <replaceable>KERNEL_VERSION</replaceable> ...'
+...
+...
+echo 'Loading Linux <replaceable>KERNEL_VERSION</replaceable> ...'
 linux /boot/vmlinuz-<replaceable>KERNEL_VERSION</replaceable>
 root=UUID=56d052b3-9148-4161-8065-3d97378d5783 ${extra_cmdline} <emphasis
 role="strong">splash=silent</emphasis> resume=/dev/disk/by-uuid/69ff0e54-23a7-4ba8-8983-5a29c54ffa5e
@@ -102,13 +81,10 @@ quiet security=apparmor crashkernel=301M,high crashkernel=72M,low mitigations=au
         </para>
       </step>
     </procedure>
-  </section>
-  <section xml:id="kernel-boot-parameters-modify-temporary-summary">
-    <title>Summary</title>
     <para>
       After executing the procedure and continuing with the boot process, you will not observe any
       splash screen for the current boot process. On the next boot, the splash screen will
       reappear.
     </para>
-  </section>
+  </example>
 </topic>

--- a/tasks/kernel-boot-parameters-modify-temporary.xml
+++ b/tasks/kernel-boot-parameters-modify-temporary.xml
@@ -54,7 +54,7 @@
       <step>
         <para>
           Press the <keycap>E</keycap> key. You are presented with an editor and the content of the
-          selected boot entry. It looks similiar to the following:
+          selected boot entry. It looks similar to the following:
         </para>
 <screen>setparams '&productname; &productnumber;'
 ...
@@ -82,9 +82,8 @@ quiet security=apparmor crashkernel=301M,high crashkernel=72M,low mitigations=au
       </step>
     </procedure>
     <para>
-      After executing the procedure and continuing with the boot process, you will not observe any
-      splash screen for the current boot process. On the next boot, the splash screen will
-      reappear.
+      After executing the procedure and continuing with the boot process, no splash screen is
+      observed for the current boot process. On the next boot, the splash screen reappears.
     </para>
   </example>
 </topic>

--- a/tasks/kernel-boot-parameters-modify-temporary.xml
+++ b/tasks/kernel-boot-parameters-modify-temporary.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This file originates from the project https://github.com/openSUSE/doc-kit -->
+<!-- This file can be edited downstream. -->
+<!DOCTYPE topic
+[
+  <!ENTITY % entities SYSTEM "../common/generic-entities.ent">
+    %entities;
+]>
+<!-- refers to legacy doc: <add github link to legacy doc piece, if applicable> -->
+<!-- point back to this document with a similar comment added to your legacy doc piece -->
+<!-- refer to README.md for file and id naming conventions -->
+<!-- metadata is dealt with on the assembly level -->
+<topic xml:id="kernel-boot-parameters-modify-temporary"
+ role="task" xml:lang="en"
+ xmlns="http://docbook.org/ns/docbook" version="5.2"
+ xmlns:its="http://www.w3.org/2005/11/its"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink"
+ xmlns:trans="http://docbook.org/ns/transclusion">
+  <info>
+    <title>Temporarily modifying kernel boot parameters</title>
+    <!-- can be changed via merge
+      in the assembly -->
+    <!-- add author's e-mail -->
+    <meta name="maintainer" content="ssarkar@suse.com" its:translate="no"/>
+    <abstract>
+      <!-- can be changed via merge in the assembly -->
+      <para>
+        To change kernel boot parameters on an experimental basis only for the upcoming boot
+        process, edit the options available on the &grub; boot screen.
+      </para>
+    </abstract>
+  </info>
+  <section xml:id="kernel-boot-parameters-modify-temporary-introduction">
+    <title>Introduction</title>
+    <para>
+      Temporary changes are helpful to debug or test the effect of modifying kernel boot
+      parameters. After you have changed the kernel boot parameters, the changes are applied for
+      the upcoming boot process. However, it does not survive subsequent boot processes.
+    </para>
+  </section>
+  <section xml:id="kernel-boot-parameters-modify-temporary-requirements">
+    <title>Requirements</title>
+    <para>
+      To modify kernel boot parameters only for the upcoming boot process, there are no strict
+      requirements. However, you must know the parameters you want to modify and their effect.
+    </para>
+  </section>
+  <section xml:id="kernel-boot-parameters-modify-temporary-procedure">
+    <title>Temporarily modify kernel boot parameters using the &grub; boot menu</title>
+    <para>
+      As an example of modifying kernel boot parameters for the upcoming boot process, we disable
+      the splash screen that you can see during the boot.
+    </para>
+    <tip>
+      <para>
+        Before modifying kernel boot parameters, create a copy of the existing stable configuration
+        somewhere outside of your system. If the boat loader gets corrupted and your system fails
+        to boot, or you face problems after booting your system, the back up helps you compare and
+        restore the parameters to the last known working configuration.
+      </para>
+    </tip>
+    <procedure>
+      <step>
+        <para>
+          Switch on your computer to start the boot process.
+        </para>
+      </step>
+      <step>
+        <para>
+          In the &grub; boot screen, highlight the entry you want to modify using the arrow keys
+          <keycap function="up"/> and <keycap function="down"/>.
+        </para>
+      </step>
+      <step>
+        <para>
+          Press the <keycap>E</keycap> key. You are presented with an editor and the content of the
+          selected boot entry. It looks similiar to the following:
+        </para>
+<screen>setparams '&productname; &productnumber;'
+ ...
+ ...
+ echo 'Loading Linux <replaceable>KERNEL_VERSION</replaceable> ...'
+linux /boot/vmlinuz-<replaceable>KERNEL_VERSION</replaceable>
+root=UUID=56d052b3-9148-4161-8065-3d97378d5783 ${extra_cmdline} <emphasis
+role="strong">splash=silent</emphasis> resume=/dev/disk/by-uuid/69ff0e54-23a7-4ba8-8983-5a29c54ffa5e
+quiet security=apparmor crashkernel=301M,high crashkernel=72M,low mitigations=auto
+</screen>
+      </step>
+      <step>
+        <para>
+          Search for the string <literal>splash=silent</literal> and remove it.
+        </para>
+      </step>
+      <step>
+        <para>
+          To boot the entry, press <keycap>F10</keycap> or <keycombo> <keycap function="control"/>
+          <keycap>X</keycap> </keycombo>.
+        </para>
+        <para>
+          To discard the changes and start anew, press the <keycap function="escape"/> key.
+        </para>
+      </step>
+    </procedure>
+  </section>
+  <section xml:id="kernel-boot-parameters-modify-temporary-summary">
+    <title>Summary</title>
+    <para>
+      After executing the procedure and continuing with the boot process, you will not observe any
+      splash screen for the current boot process. On the next boot, the splash screen will
+      reappear.
+    </para>
+  </section>
+</topic>

--- a/tasks/kernel-boot-parameters-modify-temporary.xml
+++ b/tasks/kernel-boot-parameters-modify-temporary.xml
@@ -68,7 +68,7 @@ quiet security=apparmor crashkernel=301M,high crashkernel=72M,low mitigations=au
       </step>
       <step>
         <para>
-          Search for the string <literal>splash=silent</literal> and remove it.
+          Search for the string <parameter>splash=silent</parameter> and remove it.
         </para>
       </step>
       <step>

--- a/tasks/kernel-boot-parameters-modify-troubleshoot.xml
+++ b/tasks/kernel-boot-parameters-modify-troubleshoot.xml
@@ -57,7 +57,11 @@
             </step>
             <step>
               <para>
-                Confirm that the parameters are recognized by the kernel.
+                Confirm that the parameters are recognized by the kernel. If you are modifying a
+                parameter that is already part of the standard configuration, check the output of
+                the <command>cat /proc/cmdline</command> command. For a complete list of allowed
+                parameters, refer to the kernel documentation at
+                <link xlink:href="https://www.kernel.org/doc/Documentation/admin-guide/kernel-parameters.txt"></link>.
               </para>
             </step>
           </substeps>
@@ -71,7 +75,7 @@
         </step>
         <step>
           <para>
-            Temporarily enable or disable suspicious parameters to isolate issues. For exmaple, use
+            Temporarily enable or disable suspicious parameters to isolate issues. For example, use
             the <parameter>nomodeset</parameter> to troubleshoot device driver issues related to
             graphics cards.
           </para>

--- a/tasks/kernel-boot-parameters-modify-troubleshoot.xml
+++ b/tasks/kernel-boot-parameters-modify-troubleshoot.xml
@@ -19,50 +19,165 @@
  xmlns:trans="http://docbook.org/ns/transclusion">
   <info>
     <title>Troubleshooting modified kernel boot parameters</title>
-    <!-- can be changed via merge
-      in the assembly -->
-    <!-- add author's e-mail -->
+    <!-- Title can be changed via merge in the assembly -->
     <meta name="maintainer" content="ssarkar@suse.com" its:translate="no"/>
     <abstract>
       <!-- can be changed via merge in the assembly -->
       <para>
         While modifying kernel boot parameters, challenges may arise, potentially leading to system
-        instability or boot failure. A few troubleshooting steps to address such issues are listed
-        in this section.
+        instability or boot failure. It is important to understand the potential challenges and
+        systematic approaches to resolving configuration issues.
       </para>
     </abstract>
   </info>
   <section xml:id="kernel-boot-parameters-modify-troubleshoot-common-problems">
-    <title>Common problems after modifying kernel boot parameters</title>
-    <itemizedlist>
-      <listitem>
-        <formalpara>
-          <title>Incorrect parameter</title>
+    <title>Troubleshooting kernel boot parameter modifications</title>
+    <para>
+      Effective troubleshooting requires a methodical investigation of system behaviors and
+      configuration changes. A few troubleshooting strategies and steps to address a few common
+      issues are listed in this section.
+    </para>
+    <section xml:id="sec-kernel-troubleshoot-incorrect-parameters">
+      <title>Identifying and correcting parameter issues</title>
+      <procedure>
+        <step>
           <para>
-            Ensure that the parameters' syntax and spelling are accurate, correcting any mistakes
-            or typos in the configurations.
+            Validate parameter syntax and configuration:
           </para>
-        </formalpara>
-      </listitem>
-      <listitem>
-        <formalpara>
-          <title>Boot failure</title>
+          <substeps>
+            <step>
+              <para>
+                Verify spelling accuracy of all kernel parameters.
+              </para>
+            </step>
+            <step>
+              <para>
+                Check for correct formatting without unnecessary spaces.
+              </para>
+            </step>
+            <step>
+              <para>
+                Confirm that the parameters are recognized by the kernel.
+              </para>
+            </step>
+          </substeps>
+        </step>
+        <step>
           <para>
-            If the system fails to boot, use a previous stable snapshot to rescue the system and
-            then revert the changes to restore system functionality.
+            Investigate system logs for detailed error information:
           </para>
-        </formalpara>
-      </listitem>
-      <listitem>
-        <formalpara>
-          <title>System instability</title>
+<screen>&prompt.sudo;<command>dmesg | grep -i error</command></screen>
+<screen>&prompt.sudo;<command>journalctl -b | grep -i "kernel parameter"</command></screen>
+        </step>
+        <step>
           <para>
-            If the system exhibits instability or unexpected behavior, undo the changes made to the
-            kernel boot parameters and reevert to the last working configuration. It is also
-            recommended to closely monitor the system for stability.
+            Temporarily enable or disable suspicious parameters to isolate issues. For exmaple, use
+            the <parameter>nomodeset</parameter> to troubleshoot device driver issues related to
+            graphics cards.
           </para>
-        </formalpara>
-      </listitem>
-    </itemizedlist>
+        </step>
+      </procedure>
+    </section>
+    <section xml:id="sec-kernel-troubleshoot-boot-failures">
+      <title>Recovering from boot failures</title>
+      <procedure>
+        <step>
+          <para>
+            Access system recovery options:
+          </para>
+          <itemizedlist>
+            <listitem>
+              <para>
+                Use the &grub; recovery mode during system startup.
+              </para>
+            </listitem>
+            <listitem>
+              <para>
+                Select advanced boot options to enter a minimal working environment.
+              </para>
+            </listitem>
+          </itemizedlist>
+        </step>
+        <step>
+          <para>
+            Restoration methods for different configuration approaches:
+          </para>
+          <variablelist>
+            <varlistentry>
+              <term>&yastcc; modifications</term>
+              <listitem>
+                <orderedlist>
+                  <listitem>
+                    <para>
+                      Open the &yast; Boot Loader module.
+                    </para>
+                  </listitem>
+                  <listitem>
+                    <para>
+                      Revert to previous working boot configuration.
+                    </para>
+                  </listitem>
+                  <listitem>
+                    <para>
+                      Save changes and reboot.
+                    </para>
+                  </listitem>
+                </orderedlist>
+              </listitem>
+            </varlistentry>
+            <varlistentry>
+              <term>Direct &grub; configuration restoration</term>
+              <listitem>
+                <orderedlist>
+                  <listitem>
+                    <para>
+                      Restore from pre-modification backup:
+                    </para>
+<screen>&prompt.sudo;<command>cp /etc/default/grub.bak /etc/default/grub</command></screen>
+                  </listitem>
+                  <listitem>
+                    <para>
+                      Regenerate the &grub; configuration:
+                    </para>
+<screen>&prompt.sudo;<command>grub2-mkconfig -o /boot/grub2/grub.cfg</command></screen>
+                  </listitem>
+                </orderedlist>
+              </listitem>
+            </varlistentry>
+          </variablelist>
+        </step>
+      </procedure>
+    </section>
+    <section xml:id="sec-kernel-troubleshoot-system-stability">
+      <title>Managing system stability</title>
+      <procedure>
+        <step>
+          <para>
+            Perform a comprehensive system log analysis:
+          </para>
+<screen>&prompt.sudo;<command>journalctl -xe</command></screen>
+<screen>&prompt.sudo;<command>dmesg | tail</command></screen>
+<screen>&prompt.sudo;<command>systemd-analyze verify</command></screen>
+        </step>
+        <step>
+          <para>
+            Systematically remove recently added kernel parameters.
+          </para>
+        </step>
+        <step>
+          <para>
+            Create configuration backups before modifications:
+          </para>
+<screen>&prompt.sudo;<command>cp /etc/default/grub /etc/default/grub.bak</command></screen>
+<screen>&prompt.sudo;<command>cp /boot/grub2/grub.cfg /boot/grub2/grub.cfg.bak</command></screen>
+        </step>
+        <step>
+          <para>
+            If the issues persist, consider restoring the working configurations from a backup, or
+            booting using a previously working system snapshot.
+          </para>
+        </step>
+      </procedure>
+    </section>
   </section>
 </topic>

--- a/tasks/kernel-boot-parameters-modify-troubleshoot.xml
+++ b/tasks/kernel-boot-parameters-modify-troubleshoot.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This file originates from the project https://github.com/openSUSE/doc-kit -->
+<!-- This file can be edited downstream. -->
+<!DOCTYPE topic
+[
+  <!ENTITY % entities SYSTEM "../common/generic-entities.ent">
+    %entities;
+]>
+<!-- refers to legacy doc: <add github link to legacy doc piece, if applicable> -->
+<!-- point back to this document with a similar comment added to your legacy doc piece -->
+<!-- refer to README.md for file and id naming conventions -->
+<!-- metadata is dealt with on the assembly level -->
+<topic xml:id="kernel-boot-parameters-modify-troubleshoot"
+ role="task" xml:lang="en"
+ xmlns="http://docbook.org/ns/docbook" version="5.2"
+ xmlns:its="http://www.w3.org/2005/11/its"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink"
+ xmlns:trans="http://docbook.org/ns/transclusion">
+  <info>
+    <title>Troubleshooting modified kernel boot parameters</title>
+    <!-- can be changed via merge
+      in the assembly -->
+    <!-- add author's e-mail -->
+    <meta name="maintainer" content="ssarkar@suse.com" its:translate="no"/>
+    <abstract>
+      <!-- can be changed via merge in the assembly -->
+      <para>
+        While modifying kernel boot parameters, challenges may arise, potentially leading to system
+        instability or boot failure. A few troubleshooting steps to address such issues are listed
+        in this section.
+      </para>
+    </abstract>
+  </info>
+  <section xml:id="kernel-boot-parameters-modify-troubleshoot-common-problems">
+    <title>Common problems after modifying kernel boot parameters</title>
+    <itemizedlist>
+      <listitem>
+        <formalpara>
+          <title>Incorrect parameter</title>
+          <para>
+            Ensure that the parameters' syntax and spelling are accurate, correcting any mistakes
+            or typos in the configurations.
+          </para>
+        </formalpara>
+      </listitem>
+      <listitem>
+        <formalpara>
+          <title>Boot failure</title>
+          <para>
+            If the system fails to boot, use a previous stable snapshot to rescue the system and
+            then revert the changes to restore system functionality.
+          </para>
+        </formalpara>
+      </listitem>
+      <listitem>
+        <formalpara>
+          <title>System instability</title>
+          <para>
+            If the system exhibits instability or unexpected behavior, undo the changes made to the
+            kernel boot parameters and reevert to the last working configuration. It is also
+            recommended to closely monitor the system for stability.
+          </para>
+        </formalpara>
+      </listitem>
+    </itemizedlist>
+  </section>
+</topic>

--- a/tasks/kernel-boot-parameters-modify-troubleshoot.xml
+++ b/tasks/kernel-boot-parameters-modify-troubleshoot.xml
@@ -47,7 +47,7 @@
           <substeps>
             <step>
               <para>
-                Verify spelling accuracy of all kernel parameters.
+                Verify the spelling accuracy of all kernel parameters.
               </para>
             </step>
             <step>
@@ -76,7 +76,7 @@
         <step>
           <para>
             Temporarily enable or disable suspicious parameters to isolate issues. For example, use
-            the <parameter>nomodeset</parameter> to troubleshoot device driver issues related to
+            <parameter>nomodeset</parameter> to troubleshoot device driver issues related to
             graphics cards.
           </para>
         </step>
@@ -118,7 +118,7 @@
                   </listitem>
                   <listitem>
                     <para>
-                      Revert to previous working boot configuration.
+                      Revert to the previous working boot configuration.
                     </para>
                   </listitem>
                   <listitem>
@@ -177,7 +177,7 @@
         </step>
         <step>
           <para>
-            If the issues persist, consider restoring the working configurations from a backup, or
+            If the issues persist, consider restoring the working configurations from a backup or
             booting using a previously working system snapshot.
           </para>
         </step>

--- a/tasks/kernel-boot-parameters-modify-troubleshoot.xml
+++ b/tasks/kernel-boot-parameters-modify-troubleshoot.xml
@@ -165,7 +165,7 @@
         </step>
         <step>
           <para>
-            Systematically remove recently added kernel parameters.
+            Systematically remove the recently added kernel parameters.
           </para>
         </step>
         <step>


### PR DESCRIPTION
### Description

Smart Docs - Kernel Boot Parameters.

This is a new PR because the [old PR](https://github.com/SUSE/doc-modular/pull/210) has become too corrupted with all the Git mess.


### Are there any relevant issues/feature requests?

* https://jira.suse.com/browse/DOCTEAM-1114
* bsc#...
* jsc#SLE-...


### Is this (based on) existing content?

* old xml:id...
* old URL: https://documentation.suse.com/smart/systems-management/html/task-modify-kernel-boot-parameter/index.html
