### PR TITLE
DOCTEAM-1338:Setting up a systemd service-article

### DIFF
--- a/DC-systemd-setting-up-service
+++ b/DC-systemd-setting-up-service
@@ -1,0 +1,12 @@
+MAIN="systemd-setting-up-service.asm.xml"
+ROOTID="setting-up-systemd"
+SRC_DIR="articles"
+IMG_SRC_DIR="images"
+## Profiling
+PROFOS="PRODUCT"
+#PROFCONDITION="PRODUCTNUMBER"
+#STRUCTID="STRUCTURE-ID"
+#PROFARCH="x86_64;zseries;power;aarch64"
+DOCBOOK5_RNG_URI="urn:x-suse:rng:v2:geekodoc-flat"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/articles/systemd-setting-up-service.asm.xml
+++ b/articles/systemd-setting-up-service.asm.xml
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- file: templates/articles/assembly.xml -->
+<?xml-model href="https://cdn.docbook.org/schema/5.2/rng/assemblyxi.rnc"
+            type="application/relax-ng-compact-syntax"?>
+<!DOCTYPE assembly
+[
+    <!ENTITY % entities SYSTEM "../common/generic-entities.ent">
+    %entities;
+]>
+<assembly version="5.2" xml:lang="en"
+          xmlns:xlink="http://www.w3.org/1999/xlink"
+          xmlns:trans="http://docbook.org/ns/transclusion"
+          xmlns:its="http://www.w3.org/2005/11/its"
+          xmlns="http://docbook.org/ns/docbook">
+  <!-- resources section references all topic chunks used in the final article
+    -->
+<!-- R E S O U R C E S -->
+
+  <!-- Concept files -->
+  <resources>
+    <resource xml:id="_about-systemd" href="../concepts/what-is-systemd.xml">
+      <description>About &systemd;</description>
+    </resource>
+
+    <resource xml:id="_unit-file" href="../concepts/systemd-unit-file.xml">
+      <description>Structure of a unit file</description>
+    </resource>
+    <resource xml:id="_type-unit-file" href="../concepts/types-of-systemd-unit-files.xml">
+      <description>Unit file types</description>
+    </resource>
+<resource xml:id="_concept-unit-dependencies" href="../concepts/systemd-unit-dependencies.xml">
+      <description>Unit dependencies and order</description>
+    </resource>
+    </resources>
+  <!-- Tasks -->
+  <resources>
+ <resource xml:id="_systemd-troubleshooting" href="../tasks/systemd-troubleshooting.xml">
+      <description>&systemd; troubleshooting </description>
+    </resource>
+    <resource xml:id="_create-systemd-service" href="../tasks/systemd-create-service.xml">
+      <description>Creating a Linux service with &systemd; </description>
+    </resource>
+           </resources>
+     <!-- References -->
+  <resources>
+    <resource xml:id="_systemctl-command" href="../references/systemctl-cheatsheet.xml">
+      <description>Systemctl cheat-sheet</description>
+      </resource>
+      <resource xml:id="_systemctl-edit-service-file" href="../references/systemd-editing-unit-file.xml">
+        <description>Editing a unit file</description>
+        </resource>
+        <resource xml:id="_debugg-systemd-service" href="../references/systemd-debug-failed-service.xml">
+          <description>Debugging a &systemd; service </description>
+        </resource>
+         </resources>
+  <!-- Miscellaneous -->
+
+           <resources>
+    <resource href="../common/legal.xml" xml:id="_legal">
+      <description>Legal Notice</description>
+    </resource>
+    <resource href="../common/license_gfdl1.2.xml" xml:id="_gfdl">
+      <description>GNU Free Documentation License</description>
+    </resource>
+  </resources>
+  <!-- S T R U C T U R E -->
+  <structure renderas="article" xml:id="setting-up-systemd" xml:lang="en">
+    <merge>
+      <title>Setting up a &systemd; service</title>
+      <revhistory xml:id="rh-setting-up-systemd">
+        <revision><date>2024-11-27</date>
+          <revdescription>
+            <para>
+              Initial version
+            </para>
+          </revdescription>
+        </revision>
+      </revhistory>
+      <!-- TODO: provide a listing of possible and validatable meta entry values. Maybe in our geekodoc repo? -->
+      <!-- add author's e-mail -->
+ <meta name="maintainer" content="amrita.sakthivel@suse.com" its:translate="no"/>
+      <!-- ISO date of last update as YYYY-MM-DD -->
+      <meta name="updated" content="2024-03-20" its:translate="no"/>
+      <!-- this does not work yet. Use the dm tags listed below for now
+        <meta name="bugtracker" its:translate="no">
+        <phrase role="url">https://bugzilla.suse.com/enter_bug.cgi</phrase>
+        <phrase role="component">Non-product-specific documentation</phrase>
+        <phrase role="product">Smart Docs</phrase>
+        <phrase role="assignee">assignee@suse.com</phrase>
+        </meta>
+        -->
+      <!-- not supported, yet. Use dm: tag for now
+        <meta name="translation" its:translate="no">
+        <phrase role="trans">yes</phrase>
+        <phrase role="language">de-de,cs-cz</phrase>
+        </meta>
+        -->
+      <!-- enter the platform identifier or a list of
+        identifiers, separated by ; -->
+      <meta name="architecture" its:translate="no">
+        <phrase>&x86-64;</phrase>
+        <phrase>&power;</phrase>
+      </meta>
+      <meta name="productname" its:translate="no">
+        <!-- enter product name and version --><productname
+ version="15-SP6">&sles;</productname>
+      </meta>
+      <meta name="title" its:translate="yes">Setting up a &systemd; service</meta>
+      <meta name="description" its:translate="yes">How to set up a &systemd; service.</meta>
+      <meta name="social-descr" its:translate="yes">Set up a &systemd; service</meta>
+      <!-- suitable category, comma-separated list of categories -->
+      <meta name="category" its:translate="no">
+        <phrase>Systems Management</phrase>
+      </meta>
+      <meta name="task" its:translate="no">
+        <phrase>Administration</phrase>
+        <phrase>Configuration</phrase>
+      </meta>
+      <meta name="series" its:translate="no">Product &amp; Solutions</meta>
+
+      <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+        <dm:bugtracker>
+          <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
+           <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
+          <dm:component>Documentation</dm:component>
+          <dm:assignee>amrita.sakthivel@suse.com</dm:assignee>
+        </dm:bugtracker>
+        <dm:translation>yes</dm:translation>
+      </dm:docmanager>
+      <abstract>
+<variablelist>
+          <varlistentry>
+            <term>WHAT?</term>
+            <listitem>
+              <para>
+                &systemd; is used to manage system settings and services.
+                &systemd; organizes tasks into components called <emphasis>units</emphasis> and groups of units into <emphasis>targets</emphasis>.
+
+              </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>WHY?</term>
+            <listitem>
+              <para>
+                Learn about the basics of setting up a &systemd; service; the types of services, how to edit a service,
+                debug a failed &systemd; service and get email notifications on a failed &systemd; service.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>EFFORT</term>
+            <listitem>
+              <para>
+    20 minutes of reading time.
+              </para>
+            </listitem>
+          </varlistentry>
+            <varlistentry>
+            <term>REQUIREMENTS</term>
+              <listitem>
+                <itemizedlist>
+                  <listitem>
+                    <para>
+                      Basic understanding of Linux commands
+                    </para>
+                  </listitem>
+                  <listitem>
+                  <para>
+                   Basic understanding of Linux processes, daemons, and control groups
+                  </para>
+                  </listitem>
+                    </itemizedlist>
+              </listitem>
+            </varlistentry>
+        </variablelist>
+      </abstract>
+    </merge>
+    <!-- pull in all the topic files you need -->
+ <!-- pick the appropriate type of include to match your needs -->
+    <!-- pull in a topic as is -->
+    <!-- pull in a topic and switch the title -->
+
+    <module resourceref="_about-systemd" renderas="section"/>
+    <module resourceref="_unit-file" renderas="section"/>
+    <module resourceref="_type-unit-file" renderas="section"/>
+    <module resourceref="_concept-unit-dependencies" renderas="section"/>
+    <module resourceref="_create-systemd-service" renderas="section"/>
+    <module resourceref="_systemctl-edit-service-file" renderas="section"/>
+    <module resourceref="_debugg-systemd-service" renderas="section"/>
+    <module resourceref="_systemctl-command" renderas="section"/>
+    <module resourceref="_legal" renderas="section"/>
+    <module resourceref="_gfdl" renderas="appendix"/>
+
+    <!-- Troubleshooting -->
+  </structure>
+</assembly>

--- a/references/systemd-debug-failed-service.xml
+++ b/references/systemd-debug-failed-service.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+[
+  <!ENTITY % entities SYSTEM "../common/generic-entities.ent">
+    %entities;
+]>
+<!-- refers to legacy doc: https://github.com/SUSE/doc-sle/blob/main/xml/adm_sudo.xml -->
+<!-- point back to this document with a similar comment added to your legacy doc piece -->
+<!-- refer to README.md for file and id naming conventions -->
+<!-- metadata is dealt with on the assembly level -->
+<topic xml:id="debugg-systemd-service"
+ role="task" xml:lang="en"
+ xmlns="http://docbook.org/ns/docbook" version="5.2"
+ xmlns:its="http://www.w3.org/2005/11/its"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink"
+ xmlns:trans="http://docbook.org/ns/transclusion">
+  <info>
+    <meta name="maintainer" content="amrita.sakthivel@suse.com" its:translate="no"/>
+    <title>Debugging a &systemd; service</title>
+    <abstract>
+      <para>
+Use the <command>systemctl</command> and <command>journalctl</command> commands to investigate the reasons for a failed system service.
+        </para>
+    </abstract>
+  </info>
+<para>When &systemd; fails to start a service, a generic error message is displayed, for example:</para>
+<screen>&prompt.root;<command>systemctl</command> start apache2
+Job for apache2.service failed because the control process exited with error code.
+See "systemctl status apache2.service" and "journalctl -xe" for details.</screen>
+        <variablelist>
+          <varlistentry>
+                      <term>
+List all available services and their current status:
+            </term>
+            <listitem>
+<screen>&prompt.root;<command>systemctl list-units -t service --all</command></screen>
+      <para>For example:</para>
+<screen>&prompt.root;<command>systemctl list-units -t service --all</command>
+  UNIT                                   LOAD      ACTIVE   SUB     DESCRIPTION>
+  accounts-daemon.service                loaded    active   running Accounts Se>
+  apache2.service                        loaded    failed   failed  The Apache HTTP server>
+\u25cf acpid.service                     not-found inactive dead    acpid.servi>
+ after-local.service                    loaded    inactive dead    /etc/init.d>
+  alsa-restore.service                   loaded    active   exited  Save/Restor>
+  alsa-state.service                     loaded    inactive dead    Manage Soun>
+\u25cf amavis.service                    not-found inactive dead    amavis.serv>
+  apparmor.service                       loaded    active   exited  Load AppArm>
+  appstream-sync-cache.service           loaded    inactive dead    Synchronize>
+  auditd.service                         loaded    active   running Security Au>
+  augenrules.service                     loaded    active   exited  auditd rule>
+</screen>
+      </listitem>
+          </varlistentry>
+          <varlistentry>
+             <term> If you think a specific service has failed, you can use the <literal>is-failed</literal>option:</term>
+                      <listitem>
+                         <screen>&prompt.root;<command>systemctl is-failed apache2.service</command>
+              failed</screen>
+              </listitem>
+          </varlistentry>
+          <varlistentry>
+                     <term>
+            Check the status of the failed service to find the specific error message:</term>
+     <listitem>
+<screen>&prompt.root;<command>systemctl status --full --lines=50 apache2</command>
+  ● apache2.service - Apache HTTP Server
+  Loaded: loaded (/usr/lib/systemd/system/apache2.service; enabled; vendor preset: disabled)
+  Active: failed (Result: exit-code) since Fri 2021-08-20 10:24:15 CEST; 2min 24s ago
+    Docs: https://httpd.apache.org/docs
+ Process: 2491 ExecStart=/usr/bin/apache2 --add-runtime oci=/usr/sbin/apache-runc $DOCKER_NETWORK_OPTIONS $DOCKER_OPTS >
+Main PID: 2491 (code=exited, status=1/FAILURE)
+</screen>
+                 <para> In the above example, the service ran as process ID 2491, but failed. Error messages give you a hint on what to do.
+                 </para>
+                 </listitem>
+          </varlistentry>
+          <varlistentry>
+          <term>
+          You can also use the <command>journalctl </command> command to check the log of the failed service:</term>
+          <listitem>
+
+<screen>&prompt.root; <command>journalctl --catalog --pager-end --unit=apache2</command>
+[...]
+  Aug 20 10:24:15 localhost.localdomain dockerd[2479]: unable to configure the Docker daemon with file /etc/apache2/daemon.json:
+cannot unmarshal string into Go value of type map[string]interface {}
+</screen>
+                 <para> The option <literal>--unit</literal> limits the log entries only to the failed Apache2 service.
+The error message suggests looking into the file <filename>/etc/docker/daemon.json</filename>. In this scenario,
+the error was caused by a wrong syntax. You can fix this and restart the Apache2 service. </para>
+</listitem>
+          </varlistentry>
+        </variablelist>
+      </topic>

--- a/references/systemd-editing-unit-file.xml
+++ b/references/systemd-editing-unit-file.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+[
+  <!ENTITY % entities SYSTEM "../common/generic-entities.ent">
+    %entities;
+]>
+<!-- refers to legacy doc: https://github.com/SUSE/doc-sle/blob/main/xml/adm_sudo.xml -->
+<!-- point back to this document with a similar comment added to your legacy doc piece -->
+<!-- refer to README.md for file and id naming conventions -->
+<!-- metadata is dealt with on the assembly level -->
+<topic xml:id="systemctl-edit-service-file"
+ role="reference" xml:lang="en"
+ xmlns="http://docbook.org/ns/docbook" version="5.2"
+ xmlns:its="http://www.w3.org/2005/11/its"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink"
+ xmlns:trans="http://docbook.org/ns/transclusion">
+  <info>
+    <title>The <command>sysctemctl edit </command> command </title>
+    <!--add author's email address-->
+    <meta name="maintainer" content="amrita.sakthivel@suse.com"/>
+    <abstract>
+ <para>
+        You can use the <command>systemctl</command> command to edit and modify an existing service file.
+      </para>
+    </abstract>
+  </info>
+  <para>There are three main directories where unit files are stored on the system: </para>
+  <variablelist>
+    <varlistentry>
+      <term><filename>/usr/lib/systemd/system/</filename></term>
+      <listitem>
+        <para>
+          When the RPM packages are installed, &systemd; unit files reside here.
+         </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term><filename>/run/systemd/system/</filename></term>
+      <listitem>
+        <para>
+          &systemd; unit files created at run time. This directory takes precedence over the directory with installed service unit files.
+        </para>
+  </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term><filename>/etc/systemd/system/</filename></term>
+      <listitem>
+        <para>
+         &systemd; unit files that are created by the <command>systemctl enable</command> command and also unit files added for extending a service.
+         This directory takes precedence over the directory with unit files created at run time.
+        </para>
+      </listitem>
+    </varlistentry>
+  </variablelist>
+  <para>The <command>sysctemctl edit </command> command by default opens a unit file snippet, for example:</para>
+  <screen>&prompt.sudo; systemctl edit testhttp.service</screen>
+  <para>This creates a blank file that is used to override or add directives to the unit file definition.
+A directory is created in <filename>/etc/systemd/system</filename> which contains the name of the unit file
+with <literal>.d</literal> appended. For example, a directory called <literal>testhttp.service.d</literal> is created.
+  </para>
+<para>Within the directory, a snippet called <literal>override.conf</literal> is created. &systemd; merges
+    the override snippet with the full unit file, when the unit is loaded. This snippet's directives take precedence
+    over those directives in the original unit file.
+  </para>
+  <para>You can edit the full unit file instead of creating a snippet with the <literal>--full</literal>flag. For example:
+    </para>
+    <screen>&prompt.sudo; systemctl edit --full testhttp.service</screen>
+<para>This loads the current unit file into the editor, where you can modify. When you save and exit the editor,the modified
+  file is written to <filename>/etc/systemd/system</filename>, which takes precedence over the system's unit definition usually located
+  in <filename>/lib/systemd/system</filename>.
+</para>
+<para>To remove any additions you have made, you can either delete the unit's <literal>.d</literal> configuration directory or the
+  the modified service file from <filename>/etc/systemd/system</filename>. After deleting the file or directory, reload the &systemd; process
+  so that it reverts back to the initial system process.
+</para>
+     </topic>

--- a/tasks/systemd-create-service.xml
+++ b/tasks/systemd-create-service.xml
@@ -19,12 +19,15 @@
     <meta name="maintainer" content="amrita.sakthivel@suse.com" its:translate="no"/>
     <title>Creating a Linux service with &systemd;</title>
     <abstract>
-      <para>
-        You can create an auto-start task or program that executes every time that you boot or reboot your system
+<para>
+       Create an auto-start task or program that executes every time that you boot or reboot your system
         by creating a Linux service with &systemd;.
         </para>
     </abstract>
   </info>
+  <example xml:id="systemd-auto-task">
+  <title>Using &systemd; for automatically executing tasks</title>
+
       <para>To create a custom &systemd; service, involves creating a service unit file,
         which defines the service and its behavior. </para>
     <procedure>
@@ -35,7 +38,7 @@
       specific to the system. When you place the script in this location,you make is accessible to all system users
     without a need to specify the full path. </para>
     </step>
-    <step><para>Paste the following in the file:</para>
+ <step><para>Paste the following in the file:</para>
    <screen>#!/bin/bash
      echo "Hello, Everyone!"</screen>
     </step>
@@ -55,7 +58,7 @@ ExecStart=/usr/local/bin/<replaceable>FILE_NAME.sh</replaceable>
 [Install]
 WantedBy=multi-user.target</screen>
               <para>The <literal>Unit</literal> section gives you a description of the service.
-              The <literal>Service</literal> section defines the service and its behavior.
+     The <literal>Service</literal> section defines the service and its behavior.
               The <literal>ExecStart</literal> directive specifies the command to start the service.
               The <literal>Install</literal> section specifies when the service should start.
               </para>
@@ -63,7 +66,7 @@ WantedBy=multi-user.target</screen>
                 <step><para>Save and exit the file.</para></step>
                 <step><para>To make &systemd; aware of the new service, run:
                   </para>
-                <screen>&prompt.sudo; systemctl daemon-reload</screen>
+                <screen>&prompt.sudo; systemctl <replaceable>SERVICE_NAME</replaceable></screen>
                 </step>
                 <step><para>Start,enable, and check the status of the service:</para>
                   <screen>systemctl start <replaceable>SERVICE_NAME</replaceable></screen>
@@ -71,4 +74,5 @@ WantedBy=multi-user.target</screen>
                   <screen>systemctl status <replaceable>SERVICE_NAME</replaceable></screen>
                     </step>
     </procedure>
+    </example>
       </topic>


### PR DESCRIPTION
### Description

The scope of this PR is to cover the scope of "Setting up a systemd service" as defined in https://jira.suse.com/browse/DOCTEAM-1338

**Reviewers**
Please dont review now , will tag in slack when ready.
 
**Reused** (Review not required as this topics have been reviewed and are being re-used multiple times)
- What is systemd?
- Structure of a unit file
- Unit file types
- Unit dependencies and order

**Review required**
- Creating a Linux service with systemd
- Editing a systemd unit file
- Debugging a systemd service

