### PR TITLE
Fixed link for installing NVIDIA GPU operator

### DIFF
--- a/tasks/AI-deployment-intro.xml
+++ b/tasks/AI-deployment-intro.xml
@@ -100,7 +100,7 @@
         <para>
           Install the &nvoperator; with the additional option <option>--set
           driver.enabled=false</option>. Refer to
-          <link xlink:href="https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html#rancher-kubernetes-engine-2"/>.
+          <link xlink:href="https://documentation.suse.com/suse-ai/1.0/html/NVIDIA-Operator-installation/index.html#nvidia-operator-installation"/>.
         </para>
       </step>
       <step>

--- a/tasks/AI-deployment-intro.xml
+++ b/tasks/AI-deployment-intro.xml
@@ -100,7 +100,7 @@
         <para>
           Install the &nvoperator; with the additional option <option>--set
           driver.enabled=false</option>. Refer to
-          <link xlink:href="https://documentation.suse.com/suse-ai/1.0/html/NVIDIA-Operator-installation/index.html#nvidia-operator-installation"/>.
+          <link xlink:href="&dsc;/suse-ai/1.0/html/NVIDIA-Operator-installation/index.html#nvidia-operator-installation"/>.
         </para>
       </step>
       <step>


### PR DESCRIPTION
Fixed link for installing the NVIDIA GPU operator on the SUSE Rancher Prime: RKE2 Kubernetes cluster

### Description

The older link pointed to the the NVIDIA documentation which then directed to the RKE2 documentation. But we do have a separate link that describes how we can install the NVIDIA GPU Operator on the SUSE Rancher Prime for RKE2 Kubernetes cluster with the exact configuration needed for the GPU to work seamlessly.
Hence updated the link.

