### PR TITLE
Fix layout issues in procedures: Replace orderedlist with substeps

### DIFF
--- a/concepts/copy-file-with-rsync-usage.xml
+++ b/concepts/copy-file-with-rsync-usage.xml
@@ -21,13 +21,23 @@
   <para>Copy files from the source location to the destination location as shown in the following example:</para>
   <screen>&prompt.user;<command>rsync [OPTION] SOURCE [SOURCE]... DESTINATION</command></screen>
   <para>You can have multiple <filename>SOURCE</filename> entries and the <filename>SOURCE</filename> and <filename>DESTINATION</filename> placeholders can be paths, URLs or both.</para>
-    <para>Listed below are a few use cases of copying files:</para>
-    <screen>&prompt.user;<command>rsync -av /directory1/ /directory2/</command></screen>
-    <para>In the above example, the trailing slash after the directory denotes the content of the directory and not the directory itself. In this, only the contents of <filename>directory1</filename> are copied to <filename>directory2</filename>.</para>
-    <screen>&prompt.user;<command>rsync -av /directory1 /directory2/</command></screen>
-    <para>In the above example, the directory <filename>directory1</filename> is copied to <filename>directory2</filename> resulting in <filename>/directory2/directory1/</filename>.</para>
-    <screen>&prompt.user;<command>rsync -av example1.txt example2.txt /destination/directory/</command></screen>
+  <para>Listed below are a few use cases of copying files:</para>
+
+  <itemizedlist>
+    <listitem>
+      <screen>&prompt.user;<command>rsync -av /directory1/ /destination/</command></screen>
+    <para>In the above example, the trailing slash after the directory denotes the content of the directory and not the directory itself. In this, only the contents of <filename>/directory1</filename> are copied to <filename>/destination</filename>.</para>
+    </listitem>
+    <listitem>
+      <screen>&prompt.user;<command>rsync -av /directory1 /destination/</command></screen>
+    <para>In the above example, the directory <filename>/directory1</filename> is copied to <filename>/destination</filename> resulting in <filename>/directory2/directory1/</filename>.</para>
+    </listitem>
+    <listitem>
+      <screen>&prompt.user;<command>rsync -av example1.txt example2.txt /destination/directory/</command></screen>
     <para>The above example shows copying the files <filename>example1.txt</filename> and <filename>example2.txt</filename> to the destination directory.</para>
+    </listitem>
+  </itemizedlist>
+
     <para>The commonly used <filename>OPTIONS</filename> are listed below: </para>
       <itemizedlist>
       <listitem>

--- a/tasks/copy-file-with-rsyc-configure-rsync-server.xml
+++ b/tasks/copy-file-with-rsyc-configure-rsync-server.xml
@@ -18,7 +18,6 @@
   <info>
     <title>Configuring and using an rsync server</title><!-- can be changed via merge
 in the assembly -->
-    <!-- add author's e-mail -->
     <meta name="maintainer" content="shalaka.harne@suse.com" its:translate="no"/>
     <abstract><!-- can be changed via merge in the assembly -->
       <para>
@@ -26,70 +25,68 @@ in the assembly -->
     </abstract>
   </info>
   <procedure xml:id="use-rsync"><title>Setting up an rsync server</title>
-  <para>The configuration file for the rsync daemon is separated into a main file and certain modules which hold your backup target. This makes it easier to add additional targets later. You can store global values in <filename>/etc/rsyncd.d/*.inc</filename> files, whereas your modules are placed in <filename>/etc/rsyncd.d/*.conf</filename>.</para>
-  <para>The following description explains how to create an rsync server with a backup target. This target can be used to store your backups. To create an rsync server, do the following:</para>
+  <para>The configuration file for the rsync daemon is separated into a main file and certain modules which hold your backup target. This makes it easier to add additional targets later. You can store global values in <filename>/etc/rsyncd.d/*.inc</filename> files, whereas your modules are placed in <filename>/etc/rsyncd.d/*.conf</filename>.
+  </para>
+  <para>The following description explains how to create an rsync server with a backup target. This target can be used to store your backups. To create an rsync server, do the following:
+  </para>
    <step>
-  <orderedlist>
-    <listitem><para>On your local machine, create a directory <filename>/var/backup</filename> to store all your backup files.</para>
-    <screen>&prompt.user;<command>mkdir /var/backup</command></screen></listitem>
-    <listitem><para>Specify ownership:</para>
+     <para>On your local machine, create a directory <filename>/var/backup</filename> to store all your backup files.</para>
+    <screen>&prompt.user;<command>mkdir /var/backup</command></screen>
+   </step>
+    <step>
+      <para>Specify ownership:</para>
       <para>In this example, the user <literal>tux</literal> in the group <literal>users</literal> owns the directory:</para>
     <screen>&prompt.user;<command>chown tux.users /var/backup</command></screen>
-    </listitem>
-    <listitem><para>Configure the <literal>rsyncd</literal> daemon.</para>
-   <itemizedlist><listitem><para>Create a directory <filename>/etc/rsyncd.d/</filename></para>
-  <screen>&prompt.user;<command>mkdir /etc/rsyncd.d/</command></screen>
-  </listitem>
-  <listitem><para>Create the main configuration file <filename>/etc/rsyncd.conf</filename> and add the following lines:</para>
-<screen>
-  log file = /var/log/rsync.log<co xml:id="rsync-configuration-1"/>
-  pid file = /var/lock/rsync.lock<co xml:id="rsync-configuration-2"/>
-  merge /etc/rsyncd.d<co xml:id="rsync-configuration-3"/>
-  include /etc/rsyncd.d<co xml:id="rsync-configuration-4"/></screen>
-   <calloutlist>
+    </step>
+    <step>
+      <para>Configure the <literal>rsyncd</literal> daemon:</para>
+      <substeps>
+        <step>
+          <para>Create a directory <filename>/etc/rsyncd.d/</filename></para>
+          <screen>&prompt.user;<command>mkdir /etc/rsyncd.d/</command></screen>
+        </step>
+        <step>
+          <para>Create the main configuration file
+              <filename>/etc/rsyncd.conf</filename> and add the following
+            lines:</para>
+          <screen>log file = /var/log/rsync.log<co xml:id="rsync-configuration-1" />
+pid file = /var/lock/rsync.lock<co xml:id="rsync-configuration-2" />
+merge /etc/rsyncd.d<co xml:id="rsync-configuration-3" />
+include /etc/rsyncd.d<co xml:id="rsync-configuration-4" /></screen>
+          <calloutlist>
             <callout arearefs="rsync-configuration-1">
               <para>
-               <filename>/var/log/rsync.log</filename> is the location where rsync writes the logs.
-              </para>
+                <filename>/var/log/rsync.log</filename> is the location where
+                rsync writes the logs. </para>
             </callout>
             <callout arearefs="rsync-configuration-2">
               <para>
-               <filename>/var/lock/rsync.lock</filename> is the file that contains the PID of the running rsync daemon instance.
-              </para>
+                <filename>/var/lock/rsync.lock</filename> is the file that
+                contains the PID of the running rsync daemon instance. </para>
             </callout>
             <callout arearefs="rsync-configuration-3">
-              <para>
-              Merges global values from <filename>/etc/rsyncd.d/*.inc</filename> files into the main configuration le.
-              </para>
+              <para> Merges global values from
+                  <filename>/etc/rsyncd.d/*.inc</filename> files into the main
+                configuration file. </para>
             </callout>
             <callout arearefs="rsync-configuration-4">
-              <para>
-                Loads any modules (or targets) from <filename>/etc/rsyncd.d/*.conf</filename> files. These files must not contain any references to global
-values.
-              </para>
+              <para> Loads any modules (or targets) from
+                  <filename>/etc/rsyncd.d/*.conf</filename> files. These files
+                must not contain any references to global values. </para>
             </callout>
-            </calloutlist>
-</listitem>
-<listitem><para>Create your module or your backup target in the file <filename>/etc/rsyncd.d/backup.conf</filename> with the following lines:</para>
+          </calloutlist>
+        </step>
+      </substeps>
+    </step>
+    <step>
+      <para>Create your module or your backup target in the file <filename>/etc/rsyncd.d/backup.conf</filename> with the following lines:</para>
 <screen>backup.conf: backup module
   [backup] <co xml:id="rsync-backup-1"/>
-  
-  
      uid = tux <co xml:id="rsync-backup-2"/>
-  
-  
      gid = users <co xml:id="rsync-backup-3"/>
-  
-  
      path = /var/backup <co xml:id="rsync-backup-4"/>
-  
-  
      auth users = tux <co xml:id="rsync-backup-5"/>
-  
-  
      secrets file = /etc/rsyncd.secrets <co xml:id="rsync-backup-6"/>
-  
-  
      comment = Our backup target <co xml:id="rsync-backup-7"/></screen>
      <para> In the given example:</para>
        <calloutlist>
@@ -109,24 +106,21 @@ values.
               <para><filename>auth users = tux</filename> specifies a comma-separated list of allowed users. In its simplest form, it contains the user names that are allowed to connect to this module. In our case, only user tux is allowed.</para>          
              </callout>
             <callout arearefs="rsync-backup-6">
-             <para><filename>secrets file = /etc/rsyncd.secrets</filename> specifies the path of a file that contains lines with user names and plain passwords.</para>   
+             <para><filename>secrets file = /etc/rsyncd.secrets</filename> specifies the path of a file that contains lines with user names and plain passwords.</para>
             </callout>
-        </calloutlist>  
-   </listitem>
-   </itemizedlist>
-    </listitem>
-    <listitem><para>Create the <filename>/etc/rsyncd.secrets</filename> file with the following content and replace <literal>PASSPHRASE</literal>:</para>
+        </calloutlist>
+    </step>
+    <step>
+      <para>Create the <filename>/etc/rsyncd.secrets</filename> file with the following content and replace <literal>PASSPHRASE</literal>:</para>
     <screen># user:passwd
-      tux:PASSPHRASE</screen>
-    </listitem>
-    <listitem><para>Make sure the file is only readable by root: </para>
+tux:PASSPHRASE</screen>
+    </step>
+    <step>
+     <para>Make sure the file is only readable by root: </para>
     <screen>chmod 0600 /etc/rsyncd.secrets</screen>
-    </listitem>
-  </orderedlist>
-</step>
+    </step>
 <step><para>Start and enable the <literal>rsyncd</literal> daemon with:</para>
 <screen>&prompt.user; systemctl enable rsyncd
-
 &prompt.user; systemctl start rsyncd</screen>
 </step>
 <step><para>On the remote machine, test the access to your <literal>rsync</literal> server: </para>


### PR DESCRIPTION
## Problem

Great article Shalaka! :+1: 

I just noticed that there is something off in the procedure. Inside a `<step>` you've created an `<orderedlist>` which resembles ordinary steps. :wink:  In most cases this is just wrong and gives the following layout problem:

![Screenshot_20250326_173009-1](https://github.com/user-attachments/assets/8cf69a9f-742d-4e48-aaa0-81034596df93)


## Solution

I've corrected the above issue and introduced `<step>`s and `<substeps>` which eliminates this layout issue. This looks like this:

![Screenshot_20250326_173336](https://github.com/user-attachments/assets/d4b84688-2445-44e4-9f27-62f8a6e8d028)

I didn't change the wording, just the structure and some whitespaces in screen. Unfortunately, the diff looks a bit bigger than I thought. I'd recommend to just build the HTML and see the result yourself.

Furthermore, I also added a list to improve readability in three paragraphs.

Let me know if you are fine with the changes. :slightly_smiling_face:


