### PR TITLE
AI - removed 'image:' sections from override charts

### DIFF
--- a/references/owui-helm-overrides.xml
+++ b/references/owui-helm-overrides.xml
@@ -30,11 +30,6 @@
 <screen>global:
   imagePullSecrets:
   - application-collection
-image:
-  registry: dp.apps.rancher.io
-  repository: containers/open-webui
-  tag: 0.3.32
-  pullPolicy: IfNotPresent
 ollamaUrls:
 - http://open-webui-ollama.<replaceable>SUSE_AI_NAMESPACE</replaceable>.svc.cluster.local:11434
 persistence:
@@ -42,11 +37,6 @@ persistence:
   storageClass: local-path<co xml:id="co-ollama-localpath1"/>
 ollama:
   enabled: true
-  image:
-    registry: dp.apps.rancher.io
-    repository: containers/ollama
-    tag: 0.3.6
-    pullPolicy: IfNotPresent
   ingress:
     enabled: false
   defaultModel: "gemma:2b"
@@ -148,11 +138,6 @@ extraEnvVars:
 <screen>global:
   imagePullSecrets:
   - application-collection
-image:
-  registry: dp.apps.rancher.io
-  repository: containers/open-webui
-  tag: 0.3.32
-  pullPolicy: IfNotPresent
 ollamaUrls:
 - http://ollama.<replaceable>SUSE_AI_NAMESPACE</replaceable>.svc.cluster.local:11434
 persistence:


### PR DESCRIPTION
### Description

When customers upgrade with the new chart, we don't want them to use an older image with these overrides.


### Are there any relevant issues/feature requests?

* jsc#SUSEAI-175


### Is this (based on) existing content?

* old xml:id...
* old URL...
