### PR TITLE
New article: Remote login desktop with gnome-remote-desktop

### DIFF
--- a/articles/gnome-remote-desktop.asm.xml
+++ b/articles/gnome-remote-desktop.asm.xml
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- This file originates from the project https://github.com/openSUSE/doc-kit -->
+<!-- This file can be edited downstream. -->
+<!DOCTYPE assembly
+[
+    <!ENTITY % entities SYSTEM "../common/generic-entities.ent">
+    %entities;
+]>
+<!-- refers to legacy doc: <add github link to legacy doc piece, if applicable> -->
+<!-- point back to this document with a similar comment added to your legacy doc piece -->
+<!-- refer to README.md for file and id naming conventions -->
+<assembly version="5.2" xml:lang="en"
+          xmlns:xlink="http://www.w3.org/1999/xlink"
+          xmlns:trans="http://docbook.org/ns/transclusion"
+          xmlns:its="http://www.w3.org/2005/11/its"
+          xmlns:xi="http://www.w3.org/2001/XInclude"
+          xmlns="http://docbook.org/ns/docbook">
+  <!-- resources section references all topic chunks used in the final article
+    -->
+  <!-- R E S O U R C E S -->
+  <!-- Glue files -->
+  <resources>
+    <resource xml:id="_glue-gnome-remote-desktop" href="../glues/gnome-remote-desktop.xml">
+      <description>&gnome; Remote Desktop introduction</description>
+    </resource>
+    <resource xml:id="_glue-gnome-remote-desktop-more-info" href="../glues/gnome-remote-desktop-more-info.xml">
+      <description>More information about &gnome; Remote desktop</description>
+    </resource> 
+    <!-- <resource xml:id="_glue-whats-next" href="../glues/gnome-remote-desktop-whats-next.xml">
+      <description>Glue what's next</description>
+    </resource> -->
+  <!-- Concept files -->
+  <!-- cwickert 2025-07-023: Might add a concept later, comment this out for now. -->
+  <!--   <resource xml:id="_concept-example" href="../concepts/concept.xml">
+      <description>Concept example</description>
+    </resource> -->
+  <!-- Tasks -->
+    <resource xml:id="_task-configure-gnome-remote-desktop" href="../tasks/gnome-remote-desktop-configuring.xml">
+      <description>GNOME Remote Desktop configuration</description>
+    </resource>
+  <!-- Legal -->
+    <resource href="../common/legal.xml" xml:id="_legal">
+      <description>Legal Notice</description>
+    </resource>
+    <resource href="../common/license_gfdl1.2.xml" xml:id="_gfdl">
+      <description>GNU Free Documentation License</description>
+    </resource>
+  </resources>
+  <!-- S T R U C T U R E -->
+  <structure renderas="article" xml:id="article-example" xml:lang="en">
+    <merge>
+      <title>Configuring a remote desktop server on &productname; &productnumber;</title>
+      <!-- <subtitle>Subtitle if necessary</subtitle> -->
+      <!-- Create revision history to enable versioning: adjust the placeholder revhistory ID,
+           for each entry add the date of when the updated article will be published,
+           list most recent date/entry at the top -->
+      <!-- Check https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-revhistory for detailed instructions-->
+      <revhistory xml:id="rh-gnome-remote-desktop">
+        <revision><date>FIXME</date>
+          <revdescription>
+            <para>
+              Updated for the initial release of &productname; &productnumber;
+            </para>
+          </revdescription>
+        </revision>
+        <revision><date>2025-07-03</date>
+          <revdescription>
+            <para>
+              Initial version of the document
+            </para>
+          </revdescription>
+        </revision>
+      </revhistory>
+      <!-- TODO: provide a listing of possible and validatable meta entry values. Maybe in our geekodoc repo? -->
+      <!-- add author's e-mail -->
+      <meta name="maintainer" content="cwickert@suse.com" its:translate="no"/>
+      <meta name="architecture">
+        <phrase>&aarch64;</phrase>
+        <phrase>&power;</phrase>
+        <phrase>&x86-64;</phrase>
+        <phrase>&zseries;</phrase>
+      </meta>
+      <!-- enter one or more product names and version -->
+      <meta name="productname" its:translate="no">
+        <productname version="16.0">&productname;</productname>
+      </meta>
+      <meta name="title" its:translate="yes">Configuring a remote desktop on &sls; &productnumber;</meta>
+      <meta name="description" its:translate="yes">How to configure a remote desktop on &productname; &productnumber;</meta>
+      <meta name="social-descr" its:translate="yes">Configure a remote desktop on &sls; &productnumber;</meta>
+      <!-- suitable categories has to be identical with the category selected in the docserv config -->
+      <meta name="category" its:translate="no">
+        <phrase>Systems Management</phrase>
+      </meta>
+      <!-- Determines "filter by task" filter value -->
+      <!-- either add link to list or list of tasks-->
+      <meta name="task" its:translate="no">
+        <phrase>Configuration</phrase>
+        <phrase>Installation</phrase>
+      </meta>
+      <meta name="series" its:translate="no">Products &amp; Solutions</meta>
+      <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+        <dm:bugtracker>
+          <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server 16.0</dm:product>
+          <!--
+          if the assembly applies to multiple products/productversions, use profiling:
+          <dm:product os="sles" condition="16.0">SUSE Linux Enterprise Server 16.0</dm:product>
+          <dm:product os="sles" condition="16.1">SUSE Linux Enterprise Server 16.1</dm:product>
+          -->
+          <!-- replace with your BUGZILLA e-mail address, otherwise this does not work-->
+          <dm:assignee>cwickert@suse.com</dm:assignee>
+       </dm:bugtracker>
+        <dm:translation>yes</dm:translation>
+      </dm:docmanager>
+      <abstract>
+      <variablelist>
+        <varlistentry>
+          <term>WHAT?</term>
+          <listitem>
+            <para>
+              This article describes how to set up a &gnome; remote login desktop server on
+              &productname;
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>WHY?</term>
+          <listitem>
+            <para>
+              A remote desktop server can host multiple users even without dedicated graphics
+              hardware.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>EFFORT</term>
+            <listitem>
+              <para>
+                5 minutes of configuration.
+              </para>
+            </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>GOAL</term>
+            <listitem>
+              <para>
+                Learn how to set up a remote login desktop server for multiple users.
+              </para>
+            </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>REQUIREMENTS</term>
+            <listitem>
+              <itemizedlist>
+                <listitem>
+                  <para>
+                    A system with &gnome; installed that acts as remote desktop server
+                  </para>
+                </listitem>
+                <listitem>
+                  <para>
+                    One or more client(s) to access the server via a RDP viewer
+                  </para>
+                </listitem>
+              </itemizedlist>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+      </abstract>
+    </merge>
+    <!-- pull in all the topic files you need -->
+    <!-- pick the appropriate type of include to match your needs -->
+    <!-- pull in a topic as is -->
+    <module resourceref="_glue-gnome-remote-desktop" renderas="section"/>
+    <!-- pull in a topic and switch the title -->
+    <!-- <module resourceref="_concept-example" renderas="section">
+      <merge>
+        <title>You are a very special concept now!</title>
+      </merge>
+    </module> -->
+    <module resourceref="_task-configure-gnome-remote-desktop" renderas="section"/>
+    <module resourceref="_glue-gnome-remote-desktop-more-info" renderas="section"/>
+    <!-- <module resourceref="_gnome-remote-desktop-whats-next" renderas="section"/> -->
+    <module resourceref="_legal"/>
+    <module resourceref="_gfdl">
+      <output renderas="appendix"/>
+    </module>
+  </structure>
+  <!-- TODO: second structure! -->
+</assembly>

--- a/glues/gnome-remote-desktop-more-info.xml
+++ b/glues/gnome-remote-desktop-more-info.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This file originates from the project https://github.com/openSUSE/doc-kit -->
+<!-- This file can be edited downstream. -->
+<!DOCTYPE topic
+[
+  <!ENTITY % entities SYSTEM "../common/generic-entities.ent">
+    %entities;
+]>
+<topic xml:id="glue-more-info"
+ role="glue" xml:lang="en"
+ xmlns="http://docbook.org/ns/docbook" version="5.2"
+ xmlns:its="http://www.w3.org/2005/11/its"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink"
+ xmlns:trans="http://docbook.org/ns/transclusion">
+  <info>
+    <title>For more information</title>
+    <meta name="maintainer" content="cwickert@suse.com" its:translate="no"/>
+  </info>
+  <itemizedlist>
+    <listitem>
+      <para>
+        More configuration examples are described in the &gnome; Remote Desktop README. When the
+        <package>gnome-remote-desktop</package> package installed, this file is located at
+        <filename>/usr/share/doc/packages/gnome-remote-desktop/README.md</filename>. It is also
+        available online at <link
+          xlink:href="https://github.com/GNOME/gnome-remote-desktop/blob/master/README.md"/>.
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        A complete list of options for <command>grdctl</command> can be found in <command>man 1 grdctl</command>.
+      </para>
+    </listitem>
+  </itemizedlist>
+</topic>

--- a/glues/gnome-remote-desktop.xml
+++ b/glues/gnome-remote-desktop.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This file originates from the project https://github.com/openSUSE/doc-kit -->
+<!-- This file can be edited downstream. -->
+<!DOCTYPE topic
+[
+  <!ENTITY % entities SYSTEM "../common/generic-entities.ent">
+    %entities;
+]>
+<!-- refers to legacy doc: <add github link to legacy doc piece, if applicable> -->
+<!-- point back to this document with a similar comment added to your legacy doc piece -->
+<!-- refer to README.md for naming conventions -->
+<!-- metadata is dealt with on the assembly level -->
+<topic xml:id="glue-gnome-remote-desktop"
+ role="glue" xml:lang="en"
+ xmlns="http://docbook.org/ns/docbook" version="5.2"
+ xmlns:its="http://www.w3.org/2005/11/its"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink"
+ xmlns:trans="http://docbook.org/ns/transclusion">
+  <info>
+    <title>What is &gnome; Remote Desktop?</title>
+    <meta name="maintainer" content="cwickert@suse.com" its:translate="no"/>
+    <!-- add an abstract/para here, if you need one -->
+    <!-- can be changed via merge in the assembly -->
+  </info>
+  <!-- This is an example of how a glue topic would look like. If your task contains a large number of independent subtasks, make sure to include the glue topic to provide a means of navigation and to tie them together -->
+    <para>
+      &gnome; Remote Desktop supports operating as a remote assistance remote desktop server, as a
+      single user remote desktop server, and as a remote login desktop server. 
+      This even works headless, meaning the server does not require a graphics processing unit
+      (GPU). This is particularly useful for servers, where a powerful system can serve multiple
+      users without the need for graphics hardware.
+    </para>
+    <para>
+      &gnome; Remote Desktop has two protocol backends, RDP and VNC. Not all modes of operation are
+      supported with all protocol backends.
+    </para>
+</topic>

--- a/tasks/gnome-remote-desktop-configuring.xml
+++ b/tasks/gnome-remote-desktop-configuring.xml
@@ -1,0 +1,276 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This file originates from the project https://github.com/openSUSE/doc-kit -->
+<!-- This file can be edited downstream. -->
+<!DOCTYPE topic
+[
+  <!ENTITY % entities SYSTEM "../common/generic-entities.ent">
+    %entities;
+]>
+<!-- refers to legacy doc: <add github link to legacy doc piece, if applicable> -->
+<!-- point back to this document with a similar comment added to your legacy doc piece -->
+<!-- refer to README.md for file and id naming conventions -->
+<!-- metadata is dealt with on the assembly level -->
+<topic xml:id="task-configuring-gnome-remote-desktop"
+ role="task" xml:lang="en"
+ xmlns="http://docbook.org/ns/docbook" version="5.2"
+ xmlns:its="http://www.w3.org/2005/11/its"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink"
+ xmlns:trans="http://docbook.org/ns/transclusion">
+  <info>
+    <title>Configuring &gnome; remote desktop</title>
+    <meta name="maintainer" content="cwickert@suse.com" its:translate="no"/>
+    <abstract><!-- can be changed via merge in the assembly -->
+      <para>
+        This section describes how to configure &gnome; Remote Desktop for integration with the
+        &gnome; Display Manager (GDM).
+      </para>
+    </abstract>
+  </info>
+  <section xml:id="task-example-introduction">
+    <title>Introduction</title>
+    <para>
+      GNOME Remote Desktop supports integrating with the GNOME Display Manager to achieve
+      remote login functionality.
+      <!-- cwickert 2025-07-10: FIXME next sentence out until we describe VNC as well. -->
+      <!-- This feature is only available via the RDP protocol. -->
+      It works by the remote user first authenticating with system wide credentials, which give
+      access to the graphical login screen, where users can log in using their user-specific
+      credentials.
+    </para>
+  </section>
+  <section xml:id="task-example-requirements">
+    <title>Requirements</title>
+    <itemizedlist>
+      <listitem>
+        <para>
+          A &sle; system with the &gnome; desktop environment that acts as server. You can select
+          &gnome; during installation with <menuchoice><guilabel>Software</guilabel>
+            <guilabel>Change selection</guilabel> <guilabel>&gnome; Desktop Environment
+            (Wayland)</guilabel></menuchoice>. On a running system, install &gnome; with
+            <command>zypper in -t pattern gnome</command>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          One or more client(s) with <command>gnome-connections</command>,
+          <command>remmina</command> or any other viewer that supports the RDP protocol.
+        </para>
+      </listitem>
+    </itemizedlist>
+  </section>
+  <section xml:id="task-configure-gnome-remote-desktop">
+    <title>Configuration</title>
+    <para>
+      The following procedure describes how to configure &gnome; Remote Desktop for integration
+      with &gnome; Display Manager.
+    </para>
+    <procedure>
+      <title>Configure &gnome; remote desktop </title>
+      <!-- <para>
+        A short introduction to the procedure.
+      </para> -->
+      <step xml:id="st-gnome-remote-desktop-create-directory">
+        <para>
+          Create a directory for the TLS encryption key and certificate:
+        </para>
+<screen>&prompt.sudo;-u gnome-remote-desktop <command>mkdir</command> -p <filename>~/.local/share/gnome-remote-desktop/</filename></screen>
+        <para>
+          The <systemitem class="username">gnome-remote-desktop</systemitem> user is created
+          automatically when the <package>gnome-remote-desktop</package> package is installed. Its
+          <filename>home</filename> directory is <filename>/var/lib/gnome-remote-desktop</filename>.
+        </para>
+      </step>
+      <step xml:id="st-grd-tls">
+        <para>
+          Generate a TLS key and certificate for encryption. There are different ways to do this:
+        </para>
+        <stepalternatives>
+          <step xml:id="st-gnome-remote-desktopopenssl">
+            <para>
+              With <command>openssl</command>. To generate a 4096 bit RSA key with a validity of
+              365 days, run:
+            </para>
+<screen>&prompt.sudo;-u gnome-remote-desktop <command>openssl</command> req -new -newkey rsa:4096 -days 365 -nodes -x509 -subj \
+  /C=<replaceable>COUNTRY_CODE</replaceable>/ST=<replaceable>STATE</replaceable>/L=<replaceable>LOCALITY</replaceable>/O=<replaceable>ORGANIZATION</replaceable>/CN=&exampledomain1; \
+  -out <filename>~/.local/share/gnome-remote-desktop/tls.crt</filename> \
+  -keyout <filename>~/.local/share/gnome-remote-desktop/tls.key</filename></screen>
+            <para>
+              Replace the country code, state, locality, organization, and common name or omit
+              parameters you do not need. For the country code, use a two-letter <citetitle>ISO
+                3166-1 alpha-2</citetitle> code from <link
+                xlink:href="https://www.iso.org/obp/ui/#search/code/"/>.
+            </para>
+          </step>
+          <step xml:id="st-gnome-remote-desktop-certificate-gnutls">
+            <para>
+              If you prefer an interactive command to guide you through the certificate generation,
+              use <command>certtool</command> from the <package>gnutls</package> package:
+            </para>
+<screen>&prompt.sudo;zypper in gnutls
+&prompt.sudo;-u gnome-remote-desktop <command>certtool</command> --generate-privkey --outfile <filename>~/.local/share/gnome-remote-desktop/tls.key</filename>
+&prompt.sudo;-u gnome-remote-desktop <command>certtool</command> --generate-self-signed --load-privkey  <filename>~/.local/share/gnome-remote-desktop/tls.key</filename></screen>            
+          </step>
+        </stepalternatives>
+      </step>
+      <step xml:id="st-gnome-remote-desktop-configure">
+        <para>
+          Configure GNOME Remote Desktop with <command>grdctl</command>.
+        </para>
+        <substeps>
+          <step xml:id="st-gnome-remote-desktop-configure-encryption">
+            <para>
+              Configure encryption for &gnome; Remote Desktop:
+            </para>
+<screen>&prompt.sudo;<command>grdctl</command> --system rdp set-tls-key <filename>~gnome-remote-desktop/.local/share/gnome-remote-desktop/tls.key</filename>
+&prompt.sudo;<command>grdctl</command> --system rdp set-tls-cert <filename>~gnome-remote-desktop/.local/share/gnome-remote-desktop/tls.crt</filename></screen>
+          </step>
+          <step xml:base="st-gnome-remote-desktop-configure-system-credentials">
+            <para>
+              Set the system credentials for accessing the login manager via RDP:
+            </para>
+<screen>&prompt.sudo;<command>grdctl</command> --system rdp set-credentials</screen>
+            <para>
+              This combination of user name and password is not to be confused with the individual
+              user credentials. The RDP system credentials are used by all users to access the
+              &gnome; Display Manager, where they can log in with their user credentials.
+            </para>
+          </step>
+          <step xml:id="st-gnome-remote-desktop-enable-rdp">
+            <para>
+              Enable the RDP protocol:
+            </para>
+<screen>&prompt.sudo;<command>grdctl</command> --system rdp enable</screen>
+          </step>
+        </substeps>
+      </step>
+      <step xml:id="st-enable-gnome-remote-desktop-service">
+        <para>
+          Enable and start the &gnome; Remote Desktop service:
+        </para>
+<screen>&prompt.sudo;<command>systemctl</command> enable --now gnome-remote-desktop.service</screen>
+      </step>
+      <step xml:id="st-open-firewall-gnome-remote-desktop">
+        <para>
+          Open the firewall for connections on the default RDP port:
+        </para>
+<screen>&prompt.sudo;<command>firewall-cmd</command> --permanent --add-service=rdp
+&prompt.sudo;<command>firewall-cmd</command> --reload</screen>
+      </step>
+    </procedure>
+  </section>
+  <section xml:id="task-gnome-remote-desktop-summary">
+    <title>Summary</title>
+    <para>
+      You have now configured a &gnome; Remote Desktop server. Connect to the system with
+      <command>gnome-connections</command>, <command>remmina</command> or any other viewer that
+      supports the RDP protocol.
+    </para>
+  </section>
+  <section xml:id="task-gnome-remote-desktop-troubleshooting">
+    <title>Troubleshooting</title>
+    <para>
+      If you have problems connecting to the remote desktop server, please follow these steps for
+      troubleshooting.
+    </para>
+    <procedure>
+      <step>
+        <para>
+          If you can connect to the &gnome; Display Manager but have problems logging in as user,
+          try connecting with <command>ssh</command> to verify your user password.
+        </para>
+      </step>
+      <step>
+        <para>
+          If you can connect to the remote desktop server but &gnome; Remote Desktop does not
+          accept the system credentials for the RDP connection, you may have configured them while
+          the service was already running. Restart it to pick up the changes:
+        </para>
+<screen>&prompt.sudo;<command>systemctl</command> restart gnome-remote-desktop.service</screen>
+      </step>
+      <step>
+        <para>
+          If the RDP system credentials are still not accepted, reset them:
+        </para>    
+<screen>&prompt.sudo;<command>grdctl</command> --system rdp clear-credentials
+&prompt.sudo;<command>grdctl</command> --system rdp set-credentials
+&prompt.sudo;<command>systemctl</command> restart gnome-remote-desktop.service</screen>
+      </step>
+      <step>
+        <para>
+          If you cannot reach the remote desktop server with your RDP viewer, check if the
+          gnome-remote-desktop service is running:
+        </para>
+<screen>&prompt.sudo;<command>systemctl</command> status gnome-remote-desktop</screen>
+        <stepalternatives>
+          <step>
+            <para>
+              If the service is not running, start it:
+            </para>
+<screen>&prompt.sudo;<command>systemctl</command> start gnome-remote-desktop.service</screen>
+          </step>
+          <step>
+            <para>
+              If &systemd; warns you that the configuration of <systemitem
+              class="daemon">gnome-remote-desktop.service</systemitem> was changed, make &systemd;
+              reload its configuration and restart the service:
+            </para>
+<screen>&prompt.sudo;<command>systemctl</command> daemon-reload
+&prompt.sudo;<command>systemctl</command> restart gnome-remote-desktop.service</screen>
+          </step>
+        </stepalternatives>
+      </step>
+      <step>
+        <para>
+          Check if the &gnome; Display Manager is running:
+        </para>
+<screen>&prompt.sudo;<command>systemctl</command> status display-manager.service</screen>
+        <para>
+          If you see any warnings, restart the display manager:
+        </para>
+<screen>&prompt.sudo;<command>systemctl</command> restart display-manager.service</screen>
+      </step>
+      <step>
+        <para>
+          Check that <systemitem class="daemon">gnome-remote-desktop</systemitem> is listening on
+          the default RDP port 3389:
+        </para>
+<screen>&prompt.sudo;<command>ss</command> -tulnp | grep :3389</screen>
+      </step>
+      <step>
+        <para>
+          Check that the firewall ports are open:
+        </para>
+<screen>&prompt.sudo;<command>firewall-cmd</command> --query-service=rdp</screen>   
+      </step>
+      <step>
+        <para>
+          Check that the client can reach the remote desktop server.
+        </para>
+        <substeps>
+          <step>
+            <para>
+              If you are connecting to the server by host name, check if if is is resolved
+              correctly from the client:
+            </para>
+<screen>&prompt.user;<command>host</command> <replaceable>SERVER_HOST_NAME</replaceable></screen>
+            <para>
+              If the name of the server is not resolved, try connecting to the IP address instead.
+            </para>
+          </step>
+          <step>
+            <para>
+              If the RDP viewer cannot reach the remote desktop server by IP, try pinging the
+              server:
+            </para>
+<screen>&prompt.user;<command>ping</command> -c 5 <replaceable>SERVER_IP</replaceable></screen>
+            <para>
+              If you can ping the IP address, try connecting to the remote desktop server by IP.
+              If you cannot ping the IP address, check your network setup.
+            </para>
+          </step>
+        </substeps>
+      </step>
+    </procedure>
+  </section>
+</topic>


### PR DESCRIPTION
### Description

New article about GNOME remote desktop, in particular about setting up a headless remote login remote desktop server. This is particularly useful for big servers such as IBM Z machines with a log of power but without graphics hardware.

### Are there any relevant issues/feature requests?

* [bsc#1243045](https://bugzilla.suse.com/show_bug.cgi?id=1243045)
* [jsc#DOCTEAM-1871](https://jira.suse.com/browse/DOCTEAM-1871)


### Is this (based on) existing content?

Nope.

### Note: I used "GNOME Remote Desktop" and "GNOME Display Manager (uppercase initials) when referring to the two programs, but also "remote desktop" and "display manager" (lowercase) for the general concept. I tried to be consistent but it looks weird nevertheless. 