### PR TITLE
SL Micro 6.x: Clarify AArch64 architectural requirements

### DIFF
--- a/references/alp-requirements.xml
+++ b/references/alp-requirements.xml
@@ -66,7 +66,7 @@
         <term>CPU</term>
         <listitem>
           <para>
-            &x86-64; v2, &aarch64;, &zseries;&mdash;z14 and higher, and &power;&nbsp;9 and higher CPU architectures are
+            &x86-64; v2, &aarch64; &armv8;.0-A, &zseries;&mdash;z14 and higher, and &power;&nbsp;9 and higher CPU architectures are
             supported. See <xref linkend="hardware-requirements-cpu-identification"/> for instructions 
             on checking if your CPU is supported.
           </para>


### PR DESCRIPTION
### Description

Clarify the minimum architecture level for AArch64, as requested by @lvicoun.


### Are there any relevant issues/feature requests?

* jsc#PED-12858


### Is this (based on) existing content?

No.