### PR TITLE
Add snippets for QDevice and Qnetd

### DIFF
--- a/concepts/ha-core-concepts.xml
+++ b/concepts/ha-core-concepts.xml
@@ -91,17 +91,9 @@
     </para>
   </section>
 
- <section xml:id="ha-core-concepts-quorum-determination">
-    <title>Quorum determination</title>
-    <para>
-      When communication fails between one or more nodes and the rest of the cluster (a
-      <emphasis>split-brain scenario</emphasis>), a cluster <emphasis>partition</emphasis> occurs.
-      The nodes can only communicate with other nodes in the same partition and are unaware of the
-      separated nodes. A cluster partition has <emphasis>quorum</emphasis> (or is
-      <quote>quorate</quote>) if it has the majority of nodes (or <quote>votes</quote>).
-      This is determined by <emphasis>quorum calculation</emphasis>. Quorum must be calculated
-      to allow <emphasis>fencing</emphasis> of non-quorate nodes.
-    </para>
+ <section xml:id="ha-core-concepts-quorum-calculation">
+    <title>Quorum calculation</title>
+    <xi:include href="../snippets/ha-quorum.xml"/>
     <para>
       &corosync; calculates quorum based on the following formula:
     </para>

--- a/concepts/ha-qdevice-what-is.xml
+++ b/concepts/ha-qdevice-what-is.xml
@@ -18,14 +18,7 @@
     <title>What are &qdevice; and &qnet;?</title>
     <meta name="maintainer" content="tahlia.richardson@suse.com" its:translate="no"/>
     <abstract>
-    <para>
-      When communication fails between one or more nodes and the rest of the cluster (a split-brain
-      scenario), a cluster partition occurs. The nodes can only communicate with other nodes in the
-      same partition and are unaware of the separated nodes. A cluster partition has
-      <emphasis>quorum</emphasis> (or is <quote>quorate</quote>) if it has the majority of nodes
-      (or <quote>votes</quote>). This is determined by <emphasis>quorum calculation</emphasis>.
-      Quorum must be calculated so the non-quorate nodes can be fenced.
-    </para>
+      <xi:include href="../snippets/ha-quorum.xml"/>
     <para>
       &qdevice; and &qnet; participate in quorum calculations in a split-brain scenario. &qdevice;
       runs on each cluster node and communicates with an arbitrator, &qnet;, to provide a
@@ -35,11 +28,59 @@
       </para>
     </abstract>
   </info>
+
+  <section xml:id="ha-qdevice-what-is-components">
+    <title>Components</title>
+    <variablelist>
+      <varlistentry>
+        <term>&qdevice; (<systemitem>corosync-qdevice</systemitem>)</term>
+        <listitem>
+          <xi:include href="../snippets/ha-qdevice.xml"/>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>&qnet; (<systemitem>corosync-qnetd</systemitem>)</term>
+        <listitem>
+          <xi:include href="../snippets/ha-qnetd.xml"/>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>Algorithms</term>
+        <listitem>
+          <para>
+            &qdevice; supports different algorithms to determine how votes are assigned.
+            <quote>Fifty-fifty split</quote> is helpful for clusters with an even number of nodes.
+            <quote>Last man standing</quote> is helpful for clusters where only one
+            <emphasis>active</emphasis> node needs to remain quorate.
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>Heuristics</term>
+        <listitem>
+          <para>
+            &qdevice; supports a set of commands (or <quote>heuristics</quote>) that run
+            when the cluster services start (or restart), when the cluster membership changes, and
+            when nodes connect to the &qnet; server. Optionally, you can also configure the commands
+            to run at regular intervals. The result is sent to &qnet; to help with the quorum
+            calculation. Heuristics can be written in any programming language.
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>Tiebreaker</term>
+        <listitem>
+          <para>
+            This is used as a fallback if the cluster partitions are equal even after the heuristics
+            results are applied. The tie-breaker vote can be configured to go to the node with the
+            lowest node ID, the highest node ID, or a specific node ID.
+          </para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+  </section>
   <section xml:id="ha-qdevice-what-is-benefits">
     <title>Benefits</title>
-    <para>
-      Configuring a cluster to use &qdevice; and &qnet; has the following benefits:
-    </para>
     <itemizedlist>
       <listitem>
         <para>
@@ -73,70 +114,6 @@
         </para>
       </listitem>
     </itemizedlist>
-  </section>
-  <section xml:id="ha-qdevice-what-is-components">
-    <title>Components</title>
-    <para>
-      A setup with &qdevice; and &qnet; consists of the following components and mechanisms:
-    </para>
-    <variablelist>
-      <varlistentry>
-        <term>&qdevice; (<systemitem>corosync-qdevice</systemitem>)</term>
-        <listitem>
-          <para>
-            &qdevice; runs together with &corosync; on each cluster node. It communicates with the
-            arbitrator &qnet; to provide a configurable number of votes to the cluster.
-          </para>
-        </listitem>
-      </varlistentry>
-      <varlistentry>
-        <term>&qnet; (<systemitem>corosync-qnetd</systemitem>)</term>
-        <listitem>
-          <para>
-            &qnet; is an arbitrator that runs outside the cluster. It provides a vote to the
-            &qdevice; service on each cluster node to help it participate in quorum decisions.
-            &qnet; can support multiple clusters if each cluster has a unique name. By default,
-            &qnet; runs the <systemitem>corosync-qnetd</systemitem> daemon as the user
-            <systemitem>coroqnetd</systemitem> in the group <systemitem>coroqnetd</systemitem>.
-            This avoids running the daemon as &rootuser;.
-          </para>
-        </listitem>
-      </varlistentry>
-      <varlistentry>
-        <term>Algorithms</term>
-        <listitem>
-          <para>
-            &qdevice; supports different algorithms to determine how votes are assigned.
-            <quote>Fifty-fifty split</quote> is helpful for clusters with an even number of nodes.
-            <quote>Last man standing</quote> is helpful for clusters where only one
-            <emphasis>active</emphasis> node needs to remain quorate.
-          </para>
-        </listitem>
-      </varlistentry>
-      <varlistentry>
-        <term>Heuristics</term>
-        <listitem>
-          <para>
-            &qdevice; supports a set of commands (or <quote>heuristics</quote>). The commands run
-            when the cluster services start (or restart), when the cluster membership changes, and
-            when nodes connect to the &qnet; server. Optionally, you can also configure the commands
-            to run at regular intervals. The commands can be written in any programming language.
-            If the commands succeed, they return <literal>0</literal>; otherwise, they return an
-            error code. The result is sent to &qnet; to help with the quorum calculation.
-          </para>
-        </listitem>
-      </varlistentry>
-      <varlistentry>
-        <term>Tiebreaker</term>
-        <listitem>
-          <para>
-            This is used as a fallback if the cluster partitions are equal even after the heuristics
-            results are applied. The tie-breaker vote can be configured to go to the node with the
-            lowest node ID, the highest node ID, or a specific node ID.
-          </para>
-        </listitem>
-      </varlistentry>
-    </variablelist>
   </section>
   <section xml:id="ha-qdevice-what-is-more-info">
     <title>For more information</title>

--- a/snippets/ha-qdevice.xml
+++ b/snippets/ha-qdevice.xml
@@ -1,0 +1,13 @@
+<!-- include like this:
+<xi:include href="../snippets/ha-qdevice.xml"/>
+-->
+<!DOCTYPE tip [
+  <!ENTITY % entities SYSTEM "../common/generic-entities.ent">
+  %entities;
+]>
+<para xmlns="http://docbook.org/ns/docbook" version="5.2"
+xmlns:xi="http://www.w3.org/2001/XInclude"
+xmlns:xlink="http://www.w3.org/1999/xlink">
+  &qdevice; runs together with &corosync; on each cluster node. It communicates with the arbitrator
+  &qnet; to provide a configurable number of votes to help with quorum calculation.
+</para>

--- a/snippets/ha-qnetd.xml
+++ b/snippets/ha-qnetd.xml
@@ -1,0 +1,14 @@
+<!-- include like this:
+<xi:include href="../snippets/ha-qnetd.xml"/>
+-->
+<!DOCTYPE tip [
+  <!ENTITY % entities SYSTEM "../common/generic-entities.ent">
+  %entities;
+]>
+<para xmlns="http://docbook.org/ns/docbook" version="5.2"
+xmlns:xi="http://www.w3.org/2001/XInclude"
+xmlns:xlink="http://www.w3.org/1999/xlink">
+  &qnet; is an arbitrator that provides a vote to the &qdevice; service running on the cluster
+  nodes. The &qnet; server runs outside the cluster, so you cannot move cluster resources to
+  this server. &qnet; can support multiple clusters if each cluster has a unique name.
+</para>

--- a/snippets/ha-quorum.xml
+++ b/snippets/ha-quorum.xml
@@ -1,0 +1,18 @@
+<!-- include like this:
+<xi:include href="../snippets/ha-quorum.xml"/>
+-->
+<!DOCTYPE tip [
+  <!ENTITY % entities SYSTEM "../common/generic-entities.ent">
+  %entities;
+]>
+<para xmlns="http://docbook.org/ns/docbook" version="5.2"
+xmlns:xi="http://www.w3.org/2001/XInclude"
+xmlns:xlink="http://www.w3.org/1999/xlink">
+  When communication fails between one or more nodes and the rest of the cluster (a
+  <emphasis>split-brain scenario</emphasis>), a cluster <emphasis>partition</emphasis> occurs.
+  The nodes can only communicate with other nodes in the same partition and are unaware of
+  the separated nodes. A cluster partition has <emphasis>quorum</emphasis> (or is
+  <quote>quorate</quote>) if it has the majority of nodes (or <quote>votes</quote>).
+  This is determined by <emphasis>quorum calculation</emphasis>. Quorum must be calculated
+  so the non-quorate nodes can be fenced.
+</para>

--- a/tasks/ha-qdevice-connecting-to-qnetd.xml
+++ b/tasks/ha-qdevice-connecting-to-qnetd.xml
@@ -18,8 +18,8 @@
     <title>Connecting &qdevice; to the &qnet; server</title>
     <meta name="maintainer" content="tahlia.richardson@suse.com" its:translate="no"/>
     <abstract>
+      <xi:include href="../snippets/ha-qdevice.xml"/>
       <para>
-        After you set up a &qnet; server, you can configure &qdevice; on the cluster nodes.
         This procedure explains how to configure &qdevice; after the cluster is already
         installed and running, not during the initial cluster setup.
       </para>

--- a/tasks/ha-qdevice-setting-up-qnetd.xml
+++ b/tasks/ha-qdevice-setting-up-qnetd.xml
@@ -18,10 +18,11 @@
     <title>Setting up the &qnet; server</title>
     <meta name="maintainer" content="tahlia.richardson@suse.com" its:translate="no"/>
     <abstract>
+      <xi:include href="../snippets/ha-qnetd.xml"/>
       <para>
-        &qnet; is the arbitrator that provides a vote to the &qdevice; service running on the cluster
-        nodes. The &qnet; server runs outside the cluster, so you cannot move cluster resources to
-        this server. &qnet; can support multiple clusters if each cluster has a unique name.
+        By default, &qnet; runs the <systemitem>corosync-qnetd</systemitem> daemon as the user
+        <systemitem>coroqnetd</systemitem> in the group <systemitem>coroqnetd</systemitem>.
+        This avoids running the daemon as &rootuser;.
       </para>
     </abstract>
   </info>


### PR DESCRIPTION
### Description

Added snippets for duplicate info about quorum, QDevice, and QNetd. Plus some other minor edits, like moving the Benefits section below the Components section.

Not connected to any jira ticket or bug; was just inspired while working on a similar structure for SBD.
