### PR TITLE
Fixed typo.

### DIFF
--- a/tasks/networkmanager-nmcli-troubleshoot.xml
+++ b/tasks/networkmanager-nmcli-troubleshoot.xml
@@ -152,7 +152,7 @@ Hard blocked: no
   <filename>/proc/net/bonding/<replaceable>bond0</replaceable></filename></para>
   <para>This file provides information about the bonding mode, active slaves, and other relevant details.</para>
   </step>
-  <step><para>If the connections are to active, activate the connections:</para>
+  <step><para>If the connections are inactive, activate the connections:</para>
     <screen><command>nmcli con up <replaceable>connectionname</replaceable></command></screen>
   </step>
   <step><para>Modify the connection if required.</para>


### PR DESCRIPTION
Changed "if the connections are to active" to "if the connections are inactive," in 
tasks/networkmanager-nmcli-troubleshoot.xml


### Are there any relevant issues/feature requests?

* bsc#...
* jsc#SLE-...


### Is this (based on) existing content?

* old xml:id...
* old URL...
