### PR TITLE
AI: Rreplaced Ollama Helm chart

### DIFF
--- a/references/ollama-helmchart.xml
+++ b/references/ollama-helmchart.xml
@@ -56,12 +56,12 @@
     <title>Basic override file with GPU and two models pulled at startup</title>
 <screen>global:
   imagePullSecrets:
-  - <replaceable>APPCO_SECRET</replaceable>
+  - application-collection
 ingress:
   enabled: false
 defaultModel: "gemma:2b"
+runtimeClassName: nvidia
 ollama:
-  runtimeClassName: "nvidia"
   models:
     pull:
       - "gemma:2b"
@@ -73,6 +73,7 @@ ollama:
     enabled: true
     type: 'nvidia'
     number: 1
+    nvidiaResource: "nvidia.com/gpu"
 persistentVolume:<co xml:id="co-ollama-persistent"/>
   enabled: true
   storageClass: local-path<co xml:id="co-ollama-localpath6"/></screen>


### PR DESCRIPTION
### Description

The provided override file does not utilize the nvidia gou when ollma is installed.
When tried to run nvidia-smi command inside ollama container is says command not found as well as when running models it runs without any gpu.


### Are there any relevant issues/feature requests?

* bsc#1249576


### Is this (based on) existing content?

* old xml:id...
* old URL...
