### PR TITLE
AI: Make section level 2 visible in side toc

### DIFF
--- a/DC-AI-preventing-hallucinations
+++ b/DC-AI-preventing-hallucinations
@@ -9,3 +9,5 @@ PROFARCH="x86-64"
 #PROFCONDITION="raw_image;deployment-bare-metal;x86-64"
 STRUCTID="ai-preventing-hallucinations"
 #XSLTPARAM='--stringparam "draft.mode=yes"'
+XSLTPARAM+=' --param toc.section.depth=2'
+XSLTPARAM+=' --param bubbletoc.section.depth=3 --param bubbletoc.max.depth=3'


### PR DESCRIPTION
### PR creator: Description

For SUSE AI you requested a deeper view of sections (see red rectangle in screenshot). With this addition, section level 2 (or deeper) are possible.

What do you think?

If you think this is a start, we could apply it to the other SUSE AI DC files.

----
Updated after https://github.com/openSUSE/suse-xsl/releases/tag/2.95.23

<img width="504" height="719" alt="image_720" src="https://github.com/user-attachments/assets/d63b648a-760d-43dd-a6f1-8c3b31093249" />

----

<img width="1313" height="772" alt="Screenshot_20251024_120720" src="https://github.com/user-attachments/assets/48f05c57-091c-4a5b-b3f2-759ee9bb199b" />

