### PR TITLE
DOCTEAM-2022 Issues in the "Different possible setups and steps" section of the PXE server article

### DIFF
--- a/articles/sles-pxe-server-setup.asm.xml
+++ b/articles/sles-pxe-server-setup.asm.xml
@@ -45,6 +45,13 @@
     <merge>
       <title>Setting Up a PXE Boot Server</title>
       <revhistory xml:id="rh-sles-pxe-server-setup">
+        <revision><date>2026-03-18</date>
+          <revdescription>
+            <para>
+              Added note clarifying that TFTP is mandatory for ppc64le architectures
+            </para>
+          </revdescription>
+        </revision>
         <revision><date>2025-11-04</date>
           <revdescription>
             <para>

--- a/concepts/sles-pxe-server-introduction.xml
+++ b/concepts/sles-pxe-server-introduction.xml
@@ -144,6 +144,12 @@
               An HTTP server (recommended with &agama;) like <literal>nginx</literal> and/or
               a TFTP server like <literal>tftp</literal> or <literal>dnsmasq</literal>.
             </para>
+            <note>
+             <title>TFTP is required for &ppc64le;</title>
+             <para>
+              The &ppc64le; architecture uses IEEE 1275 (OpenFirmware), not UEFI. Its &grub; netboot image (<filename>core.elf</filename>) is retrieved exclusively over TFTP. HTTP Boot is not supported on &ppc64le;. A TFTP server is therefore mandatory in any setup that includes &ppc64le; clients, regardless of whether HTTP is used for other architectures.
+             </para>
+            </note>
           </listitem>
         </varlistentry>
         <varlistentry>
@@ -161,7 +167,7 @@
                     ISC&mdash;as a modern replacement for ISC DHCP. For more information on &kea;,
                     refer to <link xlink:href="https://www.isc.org/kea/"></link>. For the ISC DHCP EOL
                     notice, see <link xlink:href="https://www.isc.org/dhcp/"></link>.
-                    
+
                     &kea; is a DHCP server and requires separate TFTP server software.
 
                     The &kea; DHCP server supports options for TFTP/PXE boot over IPv4 and IPv6
@@ -204,6 +210,12 @@
           </textobject>
         </mediaobject>
       </figure>
+      <note>
+       <title>TFTP is required for &ppc64le;</title>
+       <para>
+        The "HTTP with nginx" and "TFTP Delivery" branches in the figure above apply to UeFI-capable architectures (&x86-64;, &aarch64;). For &ppc64le; (IEEE 1275 / OpenFirmware), TFTP delivery is always required and HTTP Boot is not applicable.
+       </para>
+      </note>
     </section>
   </section>
 </topic>


### PR DESCRIPTION
### PR creator: Description

Added note clarifying that TFTP is mandatory for ppc64le architectures

### PR creator: Are there any relevant issues/feature requests?

* bsc#...https://bugzilla.suse.com/show_bug.cgi?id=1252038
* jsc#...https://jira.suse.com/browse/DOCTEAM-2022


### PR reviewer: Checklist for editorial review

Apart from the usual checks, please double-check also the following:

- [ ] do any new files fulfill the naming conventions specified in https://github.com/SUSE/doc-modular/blob/main/templates/README.md?
- [ ] article title/structure title: does it have the required length and does it use sentence style capitalization?
- [x] revhistory: is it up-to-date and does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-revhistory?  
- [x] backport: [16.0](https://github.com/SUSE/doc-modular/commit/70c063ee6e79f892e93d333ea1df84cac1b43657) 
- [ ] metadata: does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-taglist-smartdocs?
