### PR TITLE
DOCTEAM-2023 Issue in Creating GRUB 2 NetBoot directories for PXE server

### DIFF
--- a/articles/sles-pxe-server-setup.asm.xml
+++ b/articles/sles-pxe-server-setup.asm.xml
@@ -48,7 +48,9 @@
        <revision><date>2026-03-19</date>
         <revdescription>
          <para>
-          Clarified that Secure Boot applies only to UEFI-based architectures (&x86-64;, &aarch64;). Added <package>shim</package> package as alternative source for signed EFI files.
+          Clarified that Secure Boot applies to UEFI-based architectures (&x86-64;, &aarch64;), as
+          well as &ppc64le; which is non-UEFI. Added <package>shim</package> package as alternative source for signed EFI
+          files.
          </para>
         </revdescription>
        </revision>

--- a/articles/sles-pxe-server-setup.asm.xml
+++ b/articles/sles-pxe-server-setup.asm.xml
@@ -48,7 +48,7 @@
        <revision><date>2026-03-19</date>
         <revdescription>
          <para>
-          Clarified Secure Boot scope (UEFI/x86_64/AArch64 only) and added shim package as alternative source for signed EFI files.
+          Clarified that Secure Boot applies only to UEFI-based architectures (&x86-64;, &aarch64;). Added <package>shim</package> package as alternative source for signed EFI files.
          </para>
         </revdescription>
        </revision>

--- a/articles/sles-pxe-server-setup.asm.xml
+++ b/articles/sles-pxe-server-setup.asm.xml
@@ -45,6 +45,13 @@
     <merge>
       <title>Setting Up a PXE Boot Server</title>
       <revhistory xml:id="rh-sles-pxe-server-setup">
+       <revision><date>2026-03-19</date>
+        <revdescription>
+         <para>
+          Clarified Secure Boot scope (UEFI/x86_64/AArch64 only) and added shim package as alternative source for signed EFI files.
+         </para>
+        </revdescription>
+       </revision>
         <revision><date>2026-03-18</date>
           <revdescription>
             <para>

--- a/articles/sles-pxe-server-setup.asm.xml
+++ b/articles/sles-pxe-server-setup.asm.xml
@@ -48,9 +48,7 @@
        <revision><date>2026-03-19</date>
         <revdescription>
          <para>
-          Clarified that Secure Boot applies to UEFI-based architectures (&x86-64;, &aarch64;), as
-          well as &ppc64le; which is non-UEFI. Added <package>shim</package> package as alternative source for signed EFI
-          files.
+          Clarified Secure Boot scope to UEFI-based architectures only, documented architecture-specific limitation of the shim package, and updated signed EFI file sourcing guidance.
          </para>
         </revdescription>
        </revision>

--- a/articles/sles-pxe-server-setup.asm.xml
+++ b/articles/sles-pxe-server-setup.asm.xml
@@ -45,6 +45,13 @@
     <merge>
       <title>Setting Up a PXE Boot Server</title>
       <revhistory xml:id="rh-sles-pxe-server-setup">
+       <revision><date>2026-03-19</date>
+        <revdescription>
+         <para>
+          Clarified Secure Boot scope (UEFI/x86_64/AArch64 only) and added shim package as alternative source for signed EFI files.
+         </para>
+        </revdescription>
+       </revision>
         <revision><date>2026-03-18</date>
           <revdescription>
            <para>

--- a/tasks/sles-pxe-server-netboot-directories-uefi-secure-boot.xml
+++ b/tasks/sles-pxe-server-netboot-directories-uefi-secure-boot.xml
@@ -42,8 +42,8 @@
       architecture-specific directories under <filename>/srv/tftpboot/boot/grub2/</filename> for
       different platforms. For example, &x86-64; systems generate both UEFI
       (<filename>x86_64-efi</filename>) and legacy BIOS (<filename>i386-pc</filename>) directories,
-      while &aarch64; and &ppc64le; systems create their respective UEFI directories
-      (<filename>arm64-efi</filename> and <filename>powerpc-ieee1275</filename>).
+      and &aarch64; create their UEFI directory
+      <filename>arm64-efi</filename>. &ppc64le; systems (<filename>powerpc-ieee1275</filename>) supports secure boot too, but not UEFI; the grub bootloader is in <filename>/boot/grub2/grub.elf</filename> on the ISOs.
     </para>
     <important>
      <para>

--- a/tasks/sles-pxe-server-netboot-directories-uefi-secure-boot.xml
+++ b/tasks/sles-pxe-server-netboot-directories-uefi-secure-boot.xml
@@ -45,13 +45,34 @@
       while &aarch64; and &ppc64le; systems create their respective UEFI directories
       (<filename>arm64-efi</filename> and <filename>powerpc-ieee1275</filename>).
     </para>
+    <important>
+     <para>
+      In the context of this section, Secure Boot refers to &uefisecboot; as supported on &x86-64; and &aarch64; architectures. &grub; PXE Secure Boot for &ppc64le; (which uses a different platform-specific mechanism) is not covered here.
+     </para>
+    </important>
     <para>
       For &uefisecboot; support, which is not provided by the default unsigned
-      <filename>core.efi</filename> files, administrators can either copy signed EFI files from
-      installation media or install the <package>shim</package> package and manually copy the
-      required bootloader files (<filename>shim.efi</filename>, <filename>grub.efi</filename>,
-      <filename>MokManager.efi</filename>) to the appropriate architecture directories, ensuring
-      proper symbolic link resolution to keep all files within the TFTP root directory.
+      <filename>core.efi</filename> files, administrators can obtain signed EFI files for &uefisecboot; from either of the following sources:
+    </para>
+    <itemizedlist>
+     <listitem>
+      <para>
+       The <package>shim</package> package installed on the PXE server itself (<command>zypper
+       install shim</command>), which provides <filename>shim.efi</filename>,
+       <filename>grub.efi</filename>, and <filename>MokManager.efi</filename> under
+       <filename>/usr/share/efi/<replaceable>${ARCH}</replaceable>/</filename>. This is the
+       preferred method on a registered &productnameshort; &productnumber; system and does not require access to
+       installation media.
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       The installation media ISO (mounted and copied from <filename>/mnt/EFI/BOOT/*.efi</filename>), which is useful when the PXE server is not registered or the shim package is not available.
+      </para>
+     </listitem>
+    </itemizedlist>
+    <para>
+     The files must be copied to the appropriate architecture directories. This ensures proper symbolic link resolution to keep all files within the TFTP root directory.
     </para>
   </section>
   <section xml:id="sles-pxe-server-netboot-directories-uefi-secure-boot-requirements">

--- a/tasks/sles-pxe-server-netboot-directories-uefi-secure-boot.xml
+++ b/tasks/sles-pxe-server-netboot-directories-uefi-secure-boot.xml
@@ -28,7 +28,7 @@
       <para>
         This section explains creating &grub; NetBoot directories for PXE servers using
         <command>grub2-mknetdir</command>, which generates architecture-specific directories for
-        &x86-64; (UEFI and BIOS), &aarch64;, and &ppc64le; systems. For &uefisecboot; support,
+        &x86-64; (UEFI and BIOS), &aarch64;, and &ppc64le; systems. For Secure Boot support,
         administrators must copy signed EFI files from installation media or use the
         <package>shim</package> package to replace the default unsigned bootloader files.
       </para>
@@ -43,31 +43,35 @@
       different platforms. For example, &x86-64; systems generate both UEFI
       (<filename>x86_64-efi</filename>) and legacy BIOS (<filename>i386-pc</filename>) directories,
       and &aarch64; create their UEFI directory
-      <filename>arm64-efi</filename>. &ppc64le; systems (<filename>powerpc-ieee1275</filename>) supports secure boot too, but not UEFI; the grub bootloader is in <filename>/boot/grub2/grub.elf</filename> on the ISOs.
+      <filename>arm64-efi</filename>. &ppc64le; systems (<filename>powerpc-ieee1275</filename>) supports secure boot too; the &grub; bootloader is in <filename>/boot/grub2/grub.elf</filename> on the ISOs.
     </para>
     <important>
      <para>
-      In the context of this section, Secure Boot refers to &uefisecboot; as supported on &x86-64; and &aarch64; architectures. &grub; PXE Secure Boot for &ppc64le; (which uses a different platform-specific mechanism) is not covered here.
+      In the context of this section, Secure Boot applies to &x86-64; and &aarch64; architectures. &grub; PXE Secure Boot for &ppc64le; (which uses a different platform-specific mechanism) is not covered here.
      </para>
     </important>
     <para>
-      For &uefisecboot; support, which is not provided by the default unsigned
-      <filename>core.efi</filename> files, administrators can obtain signed EFI files for &uefisecboot; from either of the following sources:
+     For Secure Boot support, which is not provided by the default unsigned
+     <filename>core.efi</filename> files, administrators must obtain signed EFI files.
+     The signed files can be obtained from either of the following sources:
     </para>
     <itemizedlist>
      <listitem>
       <para>
-       The <package>shim</package> package installed on the PXE server itself (<command>zypper
-       install shim</command>), which provides <filename>shim.efi</filename>,
-       <filename>grub.efi</filename>, and <filename>MokManager.efi</filename> under
-       <filename>/usr/share/efi/<replaceable>${ARCH}</replaceable>/</filename>. This is the
-       preferred method on a registered &productnameshort; &productnumber; system and does not require access to
-       installation media.
+       The <package>shim</package> package installed on the PXE server (<command>zypper install
+       shim</command>), which provides <filename>shim.efi</filename>, <filename>grub.efi</filename>,
+       and <filename>MokManager.efi</filename> under
+       <filename>/usr/share/efi/<replaceable>ARCH</replaceable>/</filename>. Note that the
+       <package>shim</package> package provides files only for the architecture of the PXE server
+       itself. To support a different architecture, use the installation media ISO or manually
+       extract the files from the architecture-specific <package>shim</package> package.
       </para>
      </listitem>
      <listitem>
       <para>
-       The installation media ISO (mounted and copied from <filename>/mnt/EFI/BOOT/*.efi</filename>), which is useful when the PXE server is not registered or the shim package is not available.
+       The installation media ISO (mounted and copied from <filename>/mnt/EFI/BOOT/*.efi</filename>),
+       which provides signed EFI files for the target architecture regardless of the PXE server
+       architecture.
       </para>
      </listitem>
     </itemizedlist>
@@ -174,7 +178,7 @@
                     <para>
                       Replace <filename><replaceable>ARCH</replaceable>-efi</filename> with
                       <filename>x86_64-efi</filename> or <filename>arm64-efi</filename>&mdash;the
-                      supported architectures for &uefisecboot;.
+                      supported architectures for Secure Boot.
                     </para>
                   </callout>
                 </calloutlist>

--- a/tasks/sles-pxe-server-netboot-directories-uefi-secure-boot.xml
+++ b/tasks/sles-pxe-server-netboot-directories-uefi-secure-boot.xml
@@ -42,7 +42,7 @@
       architecture-specific directories under <filename>/srv/tftpboot/boot/grub2/</filename> for
       different platforms. For example, &x86-64; systems generate both UEFI
       (<filename>x86_64-efi</filename>) and legacy BIOS (<filename>i386-pc</filename>) directories,
-      and &aarch64; create their UEFI directory
+      and &aarch64; systems create their UEFI directory in
       <filename>arm64-efi</filename>. &ppc64le; systems (<filename>powerpc-ieee1275</filename>) supports secure boot too; the &grub; bootloader is in <filename>/boot/grub2/grub.elf</filename> on the ISOs.
     </para>
     <important>


### PR DESCRIPTION
### PR creator: Description

Clarified Secure Boot scope (UEFI/x86_64/AArch64 only) and added shim package as alternative source for signed EFI files.


### PR creator: Are there any relevant issues/feature requests?

* bsc#...https://bugzilla.suse.com/show_bug.cgi?id=1252040
* jsc#...https://jira.suse.com/browse/DOCTEAM-2023


### PR reviewer: Checklist for editorial review

Apart from the usual checks, please double-check also the following:

- [ ] do any new files fulfill the naming conventions specified in https://github.com/SUSE/doc-modular/blob/main/templates/README.md?
- [ ] article title/structure title: does it have the required length and does it use sentence style capitalization?
- [x] revhistory: is it up-to-date and does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-revhistory?  
- [x] backport: [16.0](https://github.com/SUSE/doc-modular/commit/9121c06f84db1d833d1c745a5b547bba1abc6a3c)
- [ ] metadata: does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-taglist-smartdocs?
