### PR TITLE
NVIDIA Jetson: [SLE Micro 6.0] Updates for NVIDIA JetPack 6.2.2

### DIFF
--- a/articles/NVIDIA-Jetson.asm.xml
+++ b/articles/NVIDIA-Jetson.asm.xml
@@ -66,7 +66,7 @@
   <!-- S T R U C T U R E -->
   <structure renderas="article" xml:id="nvidia-jetson" xml:lang="en">
     <merge>
-      <title>Deploying <phrase os="sles">&slsa;</phrase><phrase os="slmicro">&slm;</phrase> on &nvidia; &jetson; platforms</title>
+      <title>Deploying &slema; on &nvidia; &jetson; platforms</title>
       <!--<subtitle></subtitle>-->
       <!-- Create revision history to enable versioning; add most recent entries at the top. -->
       <!-- Check https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-revhistory for detailed instructions-->

--- a/articles/NVIDIA-Jetson.asm.xml
+++ b/articles/NVIDIA-Jetson.asm.xml
@@ -77,7 +77,7 @@
               <listitem><para>Renamed title</para></listitem>
               <listitem><para>Changed sections:</para>
                 <itemizedlist>
-                  <listitem><para>Updated section on libs with 6.2.2 URLs (<uri>bsc#1257270</uri>).</para></listitem>
+                  <listitem><para>Updated sections on KMP and libs with 6.2.2 URLs (<uri>bsc#1257270</uri>).</para></listitem>
                 </itemizedlist>
               </listitem>
             </itemizedlist>

--- a/articles/NVIDIA-Jetson.asm.xml
+++ b/articles/NVIDIA-Jetson.asm.xml
@@ -129,9 +129,7 @@
       </meta>
       <!-- enter one or more product names and version -->
       <meta name="productname" its:translate="no">
-        <productname version="15.6">&sles;</productname>
         <productname version="6.0">&slem;</productname>
-        <productname version="6.1">&slm;</productname>
       </meta>
       <meta name="title" its:translate="yes">&nvidia; &jetson; on &suse; how-to</meta>
       <meta name="description" its:translate="yes">How to configure and complement &suse; Linux on &nvidia; &jetson; platforms</meta>

--- a/tasks/NVIDIA-Jetson-kmp.xml
+++ b/tasks/NVIDIA-Jetson-kmp.xml
@@ -99,11 +99,6 @@ https://drivers.suse.com/nvidia/Jetson/NVIDIA_JetPack_6.1/sl-micro-6.0-aarch64/1
 ssdp_jetpack_update</command></screen>
           </step>
         </stepalternatives>
-        <note os="slmicro">
-          <para>&slem; 6.0 and &slm; 6.1 share a kernel.</para>
-          <para>The <literal>sl-micro-6.0-aarch64</literal> packages
-            have been tested to work on &slm; 6.1.</para>
-        </note>
       </step>
       <step>
         <para>

--- a/tasks/NVIDIA-Jetson-kmp.xml
+++ b/tasks/NVIDIA-Jetson-kmp.xml
@@ -79,18 +79,26 @@ in the assembly -->
         <para>
           Add the repositories for the Kernel Module Package:
         </para>
-<screen os="sles">&prompt.sudo;<command>zypper addrepo \
-https://drivers.suse.com/nvidia/Jetson/NVIDIA_JetPack_6.1/sle-15-sp6-aarch64/1.0/install \
+        <stepalternatives>
+          <step>
+            <para>For &nvidia; &jetpack; 6.2.2 firmware:</para>
+<screen>&prompt.sudo;<command>zypper addrepo \
+https://drivers.suse.com/nvidia/Jetson/NVIDIA_JetPack_6.2.2/sl-micro-6.0-aarch64/1.0/install/ \
 ssdp_jetpack</command>
 &prompt.sudo;<command>zypper addrepo \
-https://drivers.suse.com/nvidia/Jetson/NVIDIA_JetPack_6.1/sle-15-sp6-aarch64/1.0/update \
+https://drivers.suse.com/nvidia/Jetson/NVIDIA_JetPack_6.2.2/sl-micro-6.0-aarch64/1.0/update/ \
 ssdp_jetpack_update</command></screen>
-<screen os="slmicro">&prompt.sudo;<command>zypper addrepo \
+          </step>
+          <step>
+            <para>For &nvidia; &jetpack; 6.1 firmware:</para>
+<screen>&prompt.sudo;<command>zypper addrepo \
 https://drivers.suse.com/nvidia/Jetson/NVIDIA_JetPack_6.1/sl-micro-6.0-aarch64/1.0/install/ \
 ssdp_jetpack</command>
 &prompt.sudo;<command>zypper addrepo \
 https://drivers.suse.com/nvidia/Jetson/NVIDIA_JetPack_6.1/sl-micro-6.0-aarch64/1.0/update/ \
 ssdp_jetpack_update</command></screen>
+          </step>
+        </stepalternatives>
         <note os="slmicro">
           <para>&slem; 6.0 and &slm; 6.1 share a kernel.</para>
           <para>The <literal>sl-micro-6.0-aarch64</literal> packages


### PR DESCRIPTION
### PR creator: Description

Update repository URLs for NVIDIA JetPack 6.2.2, both generic and SLE Micro 6.0 specific.
Rename the title.
Adjust the metadata to hopefully avoid the published SLE Micro 6.0 doc saying SLES 15.6.
Start dropping non-Micro-6.0 contents from this branch, to avoid maintaining SP6 URLs here, too.

### PR creator: Are there any relevant issues/feature requests?

* bsc#1257270


### PR reviewer: Checklist for editorial review

Apart from the usual checks, please double-check also the following:

- [ ] do any new files fulfill the naming conventions specified in https://github.com/SUSE/doc-modular/blob/main/templates/README.md?
- [ ] article title/structure title: does it have the required length and does it use sentence style capitalization?
- [ ] revhistory: is it up-to-date and does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-revhistory?  
- [ ] metadata: does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-taglist-smartdocs?
