### PR TITLE
DOCTEAM-2151 core.efi embedded prefix limitation and guidance for multi-environment sub-directory PXE setups

### DIFF
--- a/articles/sles-pxe-server-setup.asm.xml
+++ b/articles/sles-pxe-server-setup.asm.xml
@@ -48,7 +48,7 @@
         <revision><date>2026-03-30</date>
           <revdescription>
             <para>
-              Added a note on <literal>core.efi</literal> embedded prefix limitation and guidance for multi-environment subdirectory PXE setups.
+              Added a note on <filename>core.efi</filename> prefix limitation and guidance for multi-environment subdirectory PXE setups.
             </para>
           </revdescription>
         </revision>

--- a/articles/sles-pxe-server-setup.asm.xml
+++ b/articles/sles-pxe-server-setup.asm.xml
@@ -45,10 +45,17 @@
     <merge>
       <title>Setting Up a PXE Boot Server</title>
       <revhistory xml:id="rh-sles-pxe-server-setup">
+        <revision><date>2026-03-30</date>
+          <revdescription>
+            <para>
+              Added a note on <literal>core.efi</literal> embedded prefix limitation and guidance for multi-environment subdirectory PXE setups.
+            </para>
+          </revdescription>
+        </revision>
         <revision><date>2026-03-18</date>
           <revdescription>
             <para>
-              Added note clarifying that TFTP is mandatory for ppc64le architectures
+              Added note clarifying that TFTP is mandatory for &ppc64le; architectures
             </para>
           </revdescription>
         </revision>


### PR DESCRIPTION
### PR creator: Description

Added a note on core.efi embedded prefix limitation and guidance for multi-environment sub-directory PXE setups.


### PR creator: Are there any relevant issues/feature requests?

* bsc#...https://bugzilla.suse.com/show_bug.cgi?id=1257460
* jsc#...https://jira.suse.com/browse/DOCTEAM-2151


### PR reviewer: Checklist for editorial review

Apart from the usual checks, please double-check also the following:

- [ ] do any new files fulfill the naming conventions specified in https://github.com/SUSE/doc-modular/blob/main/templates/README.md?
- [ ] article title/structure title: does it have the required length and does it use sentence style capitalization?
- [ ] revhistory: is it up-to-date and does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-revhistory?  
- [ ] backport: 
- [ ] metadata: does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-taglist-smartdocs?
