### PR TITLE
template: Change architecture value for Arm AArch64

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -92,7 +92,7 @@ Where the particular parts have the following meaning:
 * `x86` - for x86-64
 * `ppc` - for IBM Power PC
 * `s390`- for IBM Z
-* `aarch` - for AArch64
+* `arm` - for Arm AArch64
 
 `<assembly file name>` is the assembly file name without the asm.xml part. 
 


### PR DESCRIPTION
### PR creator: Description

Commit 09d801c122758c0302d655ad0c62bdf53257555a updated the template README, referenced from the pull request template, to mandate new files add an architecture prefix of `aarch` for AArch64.

Change that mandated value to `arm`.

It seems it was not yet in use for existing `DC-` files. NVIDIA Jetson deployment would be a candidate for adopting it going forward.


### PR creator: Are there any relevant issues/feature requests?

No.


### PR reviewer: Checklist for editorial review

Apart from the usual checks, please double-check also the following:

- [ ] do any new files fulfill the naming conventions specified in https://github.com/SUSE/doc-modular/blob/main/templates/README.md?
- [ ] article title/structure title: does it have the required length and does it use sentence style capitalization?
- [ ] revhistory: is it up-to-date and does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-revhistory?  
- [ ] metadata: does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-taglist-smartdocs?
