### PR TITLE
VMDK deployment: Fix spelling of VMware

### DIFF
--- a/articles/deployment_vmdk_images.asm.xml
+++ b/articles/deployment_vmdk_images.asm.xml
@@ -76,9 +76,9 @@
         <productname version="6.2" os="slmicro">&productname;</productname>
       </meta>
       <meta name="title" its:translate="yes">Deploying &productname; on vSphere Using VMDK Images</meta>
-      <meta name="description" its:translate="yes">How to deploy &productname; on VMWare vSphere
+      <meta name="description" its:translate="yes">How to deploy &productname; on &vmware; vSphere
       using the VMDK images</meta>
-      <meta name="social-descr" its:translate="yes">Deploy &productname; on VMWare vSphere</meta>
+      <meta name="social-descr" its:translate="yes">Deploy &productname; on &vmware; vSphere</meta>
       <!-- suitable categories has to be identical with the category selected in the docserv config -->
       
       <!-- Determines "filter by task" filter value -->


### PR DESCRIPTION
### PR creator: Description

The VMDK deployment guide has VMware misspelled in its metadata since commit c3ac3d5209008e33d1bf27ac344542e9a4a62e4b.
This affected the JSON config for the per-product overview pages of SL Micro 6.1 and 6.2.

Fix it by adopting the existing XML entity `&vmware;`.


### PR creator: Are there any relevant issues/feature requests?

No.


### PR reviewer: Checklist for editorial review

Apart from the usual checks, please double-check also the following:

- [ ] do any new files fulfill the naming conventions specified in https://github.com/SUSE/doc-modular/blob/main/templates/README.md?
- [ ] article title/structure title: does it have the required length and does it use sentence style capitalization?
- [ ] revhistory: is it up-to-date and does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-revhistory?  
- [ ] metadata: does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-taglist-smartdocs?
