### PR TITLE
Fix XML template link for assembly files

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ According to their purpose, we dinstinguish between four topic types:
    * Reference: *informs* (e.g. list of options, table with config files, default settings) - [XML template](https://github.com/SUSE/doc-modular/blob/main/templates/references/reference.xml)
    * Glue: helps *navigate* (combines texts or structures that do not fit into any of the other categories): Typical glue topics are the "For more information" and the "What's next" sections. - [XML template](https://github.com/SUSE/doc-modular/blob/main/templates/glues/glue.xml)
 
-Articles are built by bundling these topics into assembly files - organizational units that structure the topics. The assemblies are used to build coherent and meaningful documents [XML template](https://github.com/SUSE/doc-modular/blob/main/templates/articles/assembly.xml).
+Articles are built by bundling these topics into assembly files - organizational units that structure the topics. The assemblies are used to build coherent and meaningful documents [XML template](https://github.com/SUSE/doc-modular/blob/main/templates/articles/assembly.asm.xml).
 
 # Tools
 


### PR DESCRIPTION
Fixed the XML template link for assembly files in the README.

### PR creator: Description

Fix a broken link in the README


### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#...


### PR reviewer: Checklist for editorial review

Apart from the usual checks, please double-check also the following:

- [ ] do any new files fulfill the naming conventions specified in https://github.com/SUSE/doc-modular/blob/main/templates/README.md?
- [ ] article title/structure title: does it have the required length and does it use sentence style capitalization?
- [ ] revhistory: is it up-to-date and does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-revhistory?  
- [ ] metadata: does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-taglist-smartdocs?
