### PR TITLE
DOCTEAM-2234: Revised the supported hosts of SLES 16 - a SLE 12 SP5 host can install a SLES 16 guest only using virt-manager.

### DIFF
--- a/articles/virtualization-support.asm.xml
+++ b/articles/virtualization-support.asm.xml
@@ -27,6 +27,15 @@
    <merge>
      <title>Virtualization Support in &productname;</title>
      <revhistory xml:id="rh-virtualization">
+      <revision>
+       <date>2026-04-15</date>
+       <revdescription>
+        <para>
+         Revised the supported hosts of SLES 16: a SLE 12 SP5 host can install a SLES 16 guest only
+         using virt-manager.
+        </para>
+       </revdescription>
+      </revision>
        <revision><date>2026-04-01</date>
        <revdescription>
          <para>

--- a/references/virtualization-support.xml
+++ b/references/virtualization-support.xml
@@ -276,7 +276,7 @@
             </entry>
             <entry>
               <para>
-                &kvm; (&sls; 15 SP6 guest must use UEFI boot)
+                &kvm; (using <command>virt-manager</command>)
               </para>
             </entry>
           </row>


### PR DESCRIPTION
### PR creator: Description

In the section for supported hypervisors for SLES 16.0 guests:
- Removed: `KVM (SUSE Linux Enterprise Server 15 SP6 guest must use UEFI boot)`
- Added: `KVM (using virt-manager)`


### PR creator: Are there any relevant issues/feature requests?

* bsc#...https://bugzilla.suse.com/show_bug.cgi?id=1261868
* jsc#...https://jira.suse.com/browse/DOCTEAM-2234


### PR reviewer: Checklist for editorial review

Apart from the usual checks, please double-check also the following:

- [ ] do any new files fulfill the naming conventions specified in https://github.com/SUSE/doc-modular/blob/main/templates/README.md?
- [ ] article title/structure title: does it have the required length and does it use sentence style capitalization?
- [x] revhistory: is it up-to-date and does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-revhistory?  
- [x] backport: [16.0](https://github.com/SUSE/doc-modular/commit/2bcf34f3db64e4275a6e1a17407cb1658a22e05d) 
- [ ] metadata: does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-taglist-smartdocs?
