### PR TITLE
DOCTEAM-2223 Added SUSE Linux 16.O as supported host and guest operating systems

### DIFF
--- a/articles/virtualization-support.asm.xml
+++ b/articles/virtualization-support.asm.xml
@@ -31,6 +31,14 @@
        <date>2026-04-15</date>
        <revdescription>
         <para>
+         Added SUSE Linux 16.O as supported host and guest operating systems.
+        </para>
+       </revdescription>
+      </revision>
+      <revision>
+       <date>2026-04-15</date>
+       <revdescription>
+        <para>
          Revised the supported hosts of SLES 16: a SLE 12 SP5 host can install a SLES 16 guest only
          using virt-manager.
         </para>

--- a/references/virtualization-support.xml
+++ b/references/virtualization-support.xml
@@ -304,6 +304,18 @@
               </para>
             </entry>
           </row>
+          <row>
+            <entry>
+              <para>
+                &suselinux; 16.0
+              </para>
+            </entry>
+            <entry>
+              <para>
+                &kvm;
+              </para>
+            </entry>
+          </row>
         </tbody>
       </tgroup>
     </table>
@@ -410,7 +422,7 @@
       </listitem>
       <listitem>
        <para>
-        &sls; 16.0
+        &suselinux; 16.0
        </para>
       </listitem>
       <listitem>


### PR DESCRIPTION
### PR creator: Description

Added SUSE Linux 16.O as supported host and guest operating systems

### PR creator: Are there any relevant issues/feature requests?

* bsc#...https://bugzilla.suse.com/show_bug.cgi?id=1261261, https://bugzilla.suse.com/show_bug.cgi?id=1261262
* jsc#... https://jira.suse.com/browse/DOCTEAM-2223


### PR reviewer: Checklist for editorial review

Apart from the usual checks, please double-check also the following:

- [ ] do any new files fulfill the naming conventions specified in https://github.com/SUSE/doc-modular/blob/main/templates/README.md?
- [ ] article title/structure title: does it have the required length and does it use sentence style capitalization?
- [x] revhistory: is it up-to-date and does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-revhistory?  
- [x] backport: [16.0](https://github.com/SUSE/doc-modular/commit/6479bb789460111d3ffd1bd77b153d526f3abb32)
- [ ] metadata: does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-taglist-smartdocs?
