### PR TITLE
DOCTEAM-2206 Issue in "SETTING UP THE MAIN grub.cfg FILE"

### DIFF
--- a/articles/sles-pxe-server-setup.asm.xml
+++ b/articles/sles-pxe-server-setup.asm.xml
@@ -45,6 +45,14 @@
     <merge>
       <title>Setting Up a PXE Boot Server</title>
       <revhistory xml:id="rh-sles-pxe-server-setup">
+       <revision>
+        <date>2026-04-15</date>
+        <revdescription>
+         <para>
+          Fixed missing <code>config</code> variable definition in the main <filename>grub.cfg</filename> file.
+         </para>
+        </revdescription>
+       </revision>
         <revision><date>2026-03-18</date>
           <revdescription>
             <para>

--- a/articles/sles-pxe-server-setup.asm.xml
+++ b/articles/sles-pxe-server-setup.asm.xml
@@ -49,7 +49,24 @@
         <date>2026-04-15</date>
         <revdescription>
          <para>
-          Fixed missing <code>config</code> variable definition in the main <filename>grub.cfg</filename> file.
+          Fixed missing <literal>config</literal> variable in <filename>grub.cfg</filename>.
+         </para>
+         <para>
+          Standardized menu entry names for consistency across the documentation.
+         </para>
+         <para>
+          Added architecture-specific <command>grub2-mknetdir</command> commands with the
+          <option>--directory</option> option to support multiple architectures on a single TFTP
+          server.
+         </para>
+         <para>
+          Clarified that the <literal>shim</literal> package option applies only to &x86-64; and &aarch64; architectures.
+         </para>
+         <para>
+          Added a note on using HTTP for loading kernel and initrd files in boot menu entries.
+         </para>
+         <para>
+          Added &selnx; file context fix for <filename>/srv/install</filename> in the nginx troubleshooting section.
          </para>
         </revdescription>
        </revision>

--- a/articles/sles-pxe-server-setup.asm.xml
+++ b/articles/sles-pxe-server-setup.asm.xml
@@ -45,6 +45,14 @@
     <merge>
       <title>Setting Up a PXE Boot Server</title>
       <revhistory xml:id="rh-sles-pxe-server-setup">
+       <revision>
+        <date>2026-04-15</date>
+        <revdescription>
+         <para>
+          Fixed missing <code>config</code> variable definition in the main <filename>grub.cfg</filename> file.
+         </para>
+        </revdescription>
+       </revision>
         <revision><date>2026-03-30</date>
           <revdescription>
             <para>

--- a/articles/sles-pxe-server-setup.asm.xml
+++ b/articles/sles-pxe-server-setup.asm.xml
@@ -55,18 +55,19 @@
           Standardized menu entry names for consistency across the documentation.
          </para>
          <para>
-          Added architecture-specific <command>grub2-mknetdir</command> commands with the
-          <option>--directory</option> option to support multiple architectures on a single TFTP
-          server.
+          Simplified <command>grub2-mknetdir</command> to a single command that creates the
+          NetBoot directories for all installed target architectures automatically.
          </para>
          <para>
           Clarified that the <literal>shim</literal> package option applies only to &x86-64; and &aarch64; architectures.
          </para>
          <para>
-          Added a note on using HTTP for loading kernel and initrd files in boot menu entries.
+          Added a note clarifying when to explicitly override the boot protocol for loading
+          kernel and initrd files in boot menu entries.
          </para>
          <para>
-          Added &selnx; file context fix for <filename>/srv/install</filename> in the nginx troubleshooting section.
+          Moved installation repositories to <filename>/srv/www/htdocs/install</filename> and
+          removed the custom &selnx; policy for the nginx installation directory.
          </para>
         </revdescription>
        </revision>

--- a/articles/sles-pxe-server-setup.asm.xml
+++ b/articles/sles-pxe-server-setup.asm.xml
@@ -69,6 +69,18 @@
           Moved installation repositories to <filename>/srv/www/htdocs/install</filename> and
           removed the custom &selnx; policy for the nginx installation directory.
          </para>
+         <para>
+          Corrected the &grub; platform package names for &aarch64; and &ppc64le;
+          (<package>grub2-arm64-efi</package> and <package>grub2-powerpc-ieee1275</package>).
+         </para>
+         <para>
+          Removed a broken nginx <literal>location /install</literal> block that had no effect
+          on request handling.
+         </para>
+         <para>
+          Clarified how to determine the <literal>${BUILD}</literal> value when downloading
+          installation media.
+         </para>
         </revdescription>
        </revision>
         <revision><date>2026-03-30</date>
@@ -143,8 +155,8 @@
             <term>WHY?</term>
             <listitem>
               <para>
-                Automate and streamline the installation of multiple &productname;
-                &productnumber; systems over the network.
+                Automate the installation of multiple &productname; &productnumber; systems over
+                the network.
               </para>
             </listitem>
           </varlistentry>

--- a/tasks/sles-pxe-server-configure-grub2.xml
+++ b/tasks/sles-pxe-server-configure-grub2.xml
@@ -219,6 +219,21 @@ EOF
         installer system.
        </para>
     </note>
+    <note>
+     <title>Using HTTP for kernel and initrd loading</title>
+     <para>
+      By default, &grub; loads <filename>linux</filename> and <filename>initrd</filename> using the
+      same protocol it booted from. If your setup uses HTTP boot, you can explicitly specify the
+      HTTP server for loading these files:
+     </para>
+<screen>menuentry 'SLES-16.0 Online Installation' {
+linux  (http,pxe.example.net)/boot/images/SLES-16.0/${arch}/linux showopts root=live:http://pxe.example.net/boot/images/SLES-16.0/${arch}/squashfs.img ${ipcfg} ${sconsole} ${autoinstall}
+initrd (http,pxe.example.net)/boot/images/SLES-16.0/${arch}/initrd
+}</screen>
+     <para>
+      Note that hardcoding the HTTP server address will break TFTP-only setups where HTTP is not available.
+     </para>
+    </note>
   </section>
   <section xml:id="sles-pxe-server-configure-grub2-machine-specific">
     <title>Machine-specific configurations</title>
@@ -247,7 +262,7 @@ EOF
         </para>
 <screen>&prompt.sudo;<command>cat &gt; /srv/tftpboot/boot/config/aa:bb:cc:dd:ee:ff/grub.cfg &lt;&lt; 'EOF'</command>
 # Machine-specific configuration for aa:bb:cc:dd:ee:ff
-set default='SLES-16.0 Full Installation'
+set default='SLES-16.0 Local Installation'
 
 # Activate the menu-entry after 5sec timeout
 set timeout=5

--- a/tasks/sles-pxe-server-configure-grub2.xml
+++ b/tasks/sles-pxe-server-configure-grub2.xml
@@ -79,8 +79,8 @@
   <section xml:id="sles-pxe-server-configure-grub2-main-config">
     <title>Creating the &grub; configuration</title>
     <para>
-      The &grub; configuration file handles three main tasks: detecting the client's architecture, 
-      managing network interfaces and loading other configuration files. This modular 
+      The &grub; configuration file handles three main tasks: detecting the client's architecture,
+      managing network interfaces and loading other configuration files. This modular
       approach provides flexibility for different deployment scenarios.
     </para>
     <procedure xml:id="proc-create-main-grub-config">
@@ -124,6 +124,8 @@ export ifcfg
 #export sconsole
 
 # Load machine-specific configuration if available
+set config="/boot/config"
+export config
 if [ -s "${config}/${net_default_mac}/grub.cfg" ]; then
   ## Source a host specific configuration of grub menu:
   source "${config}/${net_default_mac}/grub.cfg"

--- a/tasks/sles-pxe-server-configure-grub2.xml
+++ b/tasks/sles-pxe-server-configure-grub2.xml
@@ -124,6 +124,8 @@ export ifcfg
 #export sconsole
 
 # Load machine-specific configuration if available
+set config="/boot/config"
+export config
 if [ -s "${config}/${net_default_mac}/grub.cfg" ]; then
   ## Source a host specific configuration of grub menu:
   source "${config}/${net_default_mac}/grub.cfg"

--- a/tasks/sles-pxe-server-configure-grub2.xml
+++ b/tasks/sles-pxe-server-configure-grub2.xml
@@ -220,18 +220,23 @@ EOF
        </para>
     </note>
     <note>
-     <title>Using HTTP for kernel and initrd loading</title>
+     <title>Mixing protocols for kernel and initrd loading</title>
      <para>
-      By default, &grub; loads <filename>linux</filename> and <filename>initrd</filename> using the
-      same protocol it booted from. If your setup uses HTTP boot, you can explicitly specify the
-      HTTP server for loading these files:
+      &grub; automatically prepends the protocol and server it booted from to every path it
+      loads, including the <literal>linux</literal> and <literal>initrd</literal> lines, so you
+      normally do not need to specify a protocol explicitly. Only specify it if you want &grub;
+      to load these particular files via a <emphasis>different</emphasis> protocol than the one
+      it booted with, for example booting via TFTP but fetching
+      <filename>linux</filename> and <filename>initrd</filename> over HTTP:
      </para>
 <screen>menuentry 'SLES-16.0 Online Installation' {
-linux  (http,pxe.example.net)/boot/images/SLES-16.0/${arch}/linux showopts root=live:http://pxe.example.net/boot/images/SLES-16.0/${arch}/squashfs.img ${ipcfg} ${sconsole} ${autoinstall}
-initrd (http,pxe.example.net)/boot/images/SLES-16.0/${arch}/initrd
+linux  (http,192.0.2.1)/boot/images/SLES-16.0/${arch}/linux showopts root=live:http://pxe.example.net/boot/images/SLES-16.0/${arch}/squashfs.img ${ipcfg} ${sconsole} ${autoinstall}
+initrd (http,192.0.2.1)/boot/images/SLES-16.0/${arch}/initrd
 }</screen>
      <para>
-      Note that hardcoding the HTTP server address will break TFTP-only setups where HTTP is not available.
+      Use an IP address rather than a hostname in the protocol prefix. &grub; itself resolves the
+      boot server as an IP address, and using a hostname here would trigger a separate DNS lookup
+      for every path.
      </para>
     </note>
   </section>

--- a/tasks/sles-pxe-server-configure-grub2.xml
+++ b/tasks/sles-pxe-server-configure-grub2.xml
@@ -19,27 +19,25 @@
     <meta name="maintainer" content="souvik.sarkar@suse.com" its:translate="no"/>
     <abstract>
       <para>
-        This section describes how to configure the &grub; bootloader for PXE-based booting on
+        This section describes how to configure the &grub; boot loader for PXE-based booting on
         &productname; &productnumber;. It covers creating the network boot directory structure,
-        setting up architecture-specific bootloaders, and implementing a flexible configuration
-        system that supports multiple architectures and installation scenarios.
+        setting up architecture-specific boot loaders, and building a boot menu that supports
+        multiple architectures and installation types.
       </para>
     </abstract>
   </info>
   <section xml:id="sles-pxe-server-configure-grub2-intro">
     <title>Introduction</title>
     <para>
-      &grub; serves as the network bootloader for PXE clients, loading kernel and initrd files to
-      start the &agama; installer. This section demonstrates how to create a sophisticated &grub;
-      configuration that automatically detects client architecture, manages network interface
-      selection, and provides a unified boot menu supporting multiple installation types and target
-      architectures.
+      &grub; serves as the network boot loader for PXE clients, loading kernel and initrd files to
+      start the &agama; installer. This section shows how to build a &grub; configuration that
+      detects the client architecture, selects the correct network interface, and provides one
+      boot menu covering multiple installation types and target architectures.
     </para>
     <para>
-      The configuration approach uses a modular design with separate files for architecture
-      detection, variable definitions, and boot menu entries. This enables support for
-      machine-specific configurations and automated installation profiles while maintaining
-      consistency across different hardware platforms.
+      The configuration is split into separate files for architecture detection, variable
+      definitions, and boot menu entries. This split lets you add machine-specific configurations
+      and automated installation profiles without duplicating the shared setup.
     </para>
   </section>
   <section xml:id="sles-pxe-server-configure-grub2-reqs">
@@ -61,7 +59,7 @@
         <para>
           &grub; packages for all target architectures must be installed:
           <package>grub2-x86_64-efi</package>, <package>grub2-i386-pc</package>,
-          <package>grub2-aarch64-efi</package>, and <package>grub2-ppc64le-ieee1275</package>
+          <package>grub2-arm64-efi</package>, and <package>grub2-powerpc-ieee1275</package>
         </para>
       </listitem>
       <listitem>
@@ -230,12 +228,12 @@ EOF
       <filename>linux</filename> and <filename>initrd</filename> over HTTP:
      </para>
 <screen>menuentry 'SLES-16.0 Online Installation' {
-linux  (http,192.0.2.1)/boot/images/SLES-16.0/${arch}/linux showopts root=live:http://pxe.example.net/boot/images/SLES-16.0/${arch}/squashfs.img ${ipcfg} ${sconsole} ${autoinstall}
-initrd (http,192.0.2.1)/boot/images/SLES-16.0/${arch}/initrd
+linux  (http,192.168.1.200)/boot/images/SLES-16.0/${arch}/linux showopts root=live:http://pxe.example.net/boot/images/SLES-16.0/${arch}/squashfs.img ${ipcfg} ${sconsole} ${autoinstall}
+initrd (http,192.168.1.200)/boot/images/SLES-16.0/${arch}/initrd
 }</screen>
      <para>
-      Use an IP address rather than a hostname in the protocol prefix. &grub; itself resolves the
-      boot server as an IP address, and using a hostname here would trigger a separate DNS lookup
+      Use an IP address rather than a host name in the protocol prefix. &grub; itself resolves the
+      boot server as an IP address, and using a host name here would trigger a separate DNS lookup
       for every path.
      </para>
     </note>
@@ -284,8 +282,8 @@ source "/boot/grub2/menu.cfg"
 EOF
 </screen>
         <para>
-          Alternatively, provide own menu entry in the host-specific <filename>grub.cfg</filename>
-          (e.g. generated for a specific boot attempt):
+          Alternatively, provide your own menu entry in the host-specific <filename>grub.cfg</filename>,
+          for example generated for a specific boot attempt:
         </para>
 <screen>&prompt.sudo;<command>cat &gt; /srv/tftpboot/boot/config/aa:bb:cc:dd:ee:ff/grub.cfg &lt;&lt; 'EOF'</command>
 set default='SLES-16.0 Auto-Installation'
@@ -514,7 +512,7 @@ EOF
     <section xml:id="sles-pxe-server-grub2-troubleshoot-efi">
       <title>EFI boot failures</title>
       <para>
-        EFI and Secure Boot issues can prevent proper bootloader initialization or cause
+        EFI and Secure Boot issues can prevent proper boot loader initialization or cause
         authentication failures.
       </para>
       <procedure xml:id="proc-debug-efi-boot">
@@ -551,7 +549,7 @@ EOF
         </step>
         <step>
           <para>
-            Check that the DHCP configuration provides the correct bootloader paths:
+            Check that the DHCP configuration provides the correct boot loader paths:
           </para>
 <screen>&prompt.user;<command>grep -n "bootx64.efi\|shim.efi\|bootaa64.efi"
 /etc/dnsmasq.d/dhcp.conf /etc/kea/kea-dhcp?.conf /etc/dhcpd?.conf</command></screen>
@@ -628,8 +626,8 @@ EOF
     <section xml:id="sles-pxe-server-grub2-troubleshoot-logging">
       <title>Enabling detailed logging</title>
       <para>
-        For persistent issues, enable comprehensive logging to capture detailed information about
-        the boot process.
+        For persistent issues, enable logging to capture detailed information about the boot
+        process.
       </para>
       <procedure xml:id="proc-enable-grub-logging">
         <title>Setting up &grub; debug logging</title>
@@ -641,7 +639,7 @@ EOF
         </step>
         <step>
           <para>
-            Add comprehensive debug output:
+            Add debug output:
           </para>
 <screen>&prompt.sudo;<command>cat &gt; /srv/tftpboot/boot/grub2/debug.cfg &lt;&lt; 'EOF'</command>
 # Debug configuration for GRUB troubleshooting
@@ -697,51 +695,51 @@ EOF
    <itemizedlist>
     <listitem>
      <para>
-       <emphasis role="bold">DHCP boot file name</emphasis>&mdash;the boot filename delivered to the
+       <emphasis role="bold">DHCP boot file name:</emphasis> the boot filename delivered to the
        client must include the custom prefix. For example,
        <filename>/<replaceable>ENV1</replaceable>/boot/grub2/x86_64-efi/bootx64.efi</filename>.
      </para>
     </listitem>
     <listitem>
      <para>
-      <emphasis role="bold">nginx location alias</emphasis>&mdash;the <literal>location /boot</literal>
-      block in <filename>/etc/nginx/nginx.conf</filename> must be updated to expose the custom
-      prefix path.
+      <emphasis role="bold">nginx location alias:</emphasis> update the <literal>location /boot</literal>
+      block in <filename>/etc/nginx/nginx.conf</filename> to expose the custom prefix path.
      </para>
      </listitem>
      <listitem>
       <para>
-       <emphasis role="bold"><filename>grub.cfg</filename> source paths</emphasis>&mdash;the hardcoded
-       absolute paths inside <filename>/srv/tftpboot/boot/grub2/grub.cfg</filename>:
+       <emphasis role="bold"><filename>grub.cfg</filename> source paths:</emphasis> update the
+       hardcoded absolute paths inside <filename>/srv/tftpboot/boot/grub2/grub.cfg</filename>:
       </para>
 <screen>source "${config}/${net_default_mac}/grub.cfg"</screen>
 <screen>source "${prefix}/menu.cfg"</screen>
       <para>
-       Both must be updated to use the custom prefix.
+       Both must use the custom prefix.
       </para>
      </listitem>
      <listitem>
       <para>
-       <emphasis role="bold"><filename>menu.cfg</filename> paths</emphasis>&mdash;all
-       <filename>/boot/images/...</filename> paths inside <filename>menu.cfg</filename> must be
-       updated to use the custom prefix.
+       <emphasis role="bold"><filename>menu.cfg</filename> paths:</emphasis> update all
+       <filename>/boot/images/...</filename> paths inside <filename>menu.cfg</filename> to use the
+       custom prefix.
       </para>
      </listitem>
      <listitem>
       <para>
-       <emphasis role="bold">Per-MAC host configurations</emphasis>&mdash;if you use machine-specific configurations, the
-       <literal>source "/boot/grub2/menu.cfg"</literal> line inside each per-MAC <filename>grub.cfg</filename> must also be updated to use the custom prefix.
+       <emphasis role="bold">Per-MAC host configurations:</emphasis> if you use machine-specific
+       configurations, also update the <literal>source "/boot/grub2/menu.cfg"</literal> line
+       inside each per-MAC <filename>grub.cfg</filename> to use the custom prefix.
       </para>
      </listitem>
      <listitem>
       <para>
-       <emphasis role="bold">&selnx; file context</emphasis>&mdash;run <command>restorecon</command> on your custom path:
+       <emphasis role="bold">&selnx; file context:</emphasis> run <command>restorecon</command> on your custom path:
       </para>
 <screen>&prompt.sudo;<command>restorecon -Rv /srv/tftpboot/<replaceable>ENV1</replaceable></command></screen>
      </listitem>
      <listitem>
       <para>
-       <emphasis role="bold">&selnx; policy</emphasis>&mdash; running <command>setsebool -P
+       <emphasis role="bold">&selnx; policy:</emphasis> running <command>setsebool -P
        httpd_serve_cobbler_files=1</command> only covers the standard <filename>/boot</filename>
        path. A custom &selnx; policy is required for a non-standard prefix. Use <command>ausearch -m avc -ts recent</command>
        to identify denials and create the appropriate policy module.
@@ -752,7 +750,7 @@ EOF
   <section xml:id="sles-pxe-server-configure-grub2-next-steps">
     <title>Next steps</title>
     <para>
-      With &grub; properly configured, you can proceed to:
+      &grub; is now configured. The remaining tasks are:
     </para>
     <itemizedlist>
       <listitem>
@@ -762,7 +760,7 @@ EOF
       </listitem>
       <listitem>
         <para>
-          Set up DHCP services to direct PXE clients to the appropriate bootloaders
+          Set up DHCP services to direct PXE clients to the appropriate boot loaders
         </para>
       </listitem>
       <listitem>
@@ -771,10 +769,5 @@ EOF
         </para>
       </listitem>
     </itemizedlist>
-    <para>
-      The flexible &grub; configuration system provides a foundation for sophisticated PXE
-      deployment scenarios, supporting multiple architectures and installation types through a
-      unified interface.
-    </para>
   </section>
 </topic>

--- a/tasks/sles-pxe-server-http-nginx.xml
+++ b/tasks/sles-pxe-server-http-nginx.xml
@@ -246,6 +246,25 @@ EOF
           </para>
 <screen>&prompt.sudo;<command>chmod -R 755 /srv/tftpboot/boot /srv/install</command></screen>
         </step>
+        <step>
+         <para>
+          If nginx still cannot serve files from <filename>/srv/install</filename>, the
+          directory may require additional &selnx; file context configuration. Run the
+          following commands to equivalence <filename>/srv/install</filename> to
+          <filename>/srv/www</filename> and restore the file context:
+         </para>
+<screen>&prompt.sudo;<command>semanage fcontext -e /srv/www -a /srv/install</command></screen>
+<screen>&prompt.sudo;<command>restorecon -RFv /srv/install/</command></screen>
+         <note>
+          <title>&selnx; file context for <filename>/srv/install</filename></title>
+          <para>
+           This step may be required in addition to
+           <command>setsebool -P httpd_serve_cobbler_files=1</command>. Use
+           <command>ausearch -m avc -ts recent</command> to check for &selnx; denials
+           before and after applying these changes.
+          </para>
+         </note>
+       </step>
       </procedure>
     </section>
     <section xml:id="sles-pxe-server-nginx-troubleshoot-port">

--- a/tasks/sles-pxe-server-http-nginx.xml
+++ b/tasks/sles-pxe-server-http-nginx.xml
@@ -63,8 +63,8 @@
   <section xml:id="sles-pxe-server-configure-nginx-setup">
     <title>Configuring nginx for PXE boot</title>
     <para>
-      The nginx configuration defines location aliases that expose the TFTP boot directory and
-      installation repositories through HTTP URLs.
+      The nginx configuration exposes the TFTP boot directory through a dedicated location alias,
+      and serves installation repositories directly from the document root.
     </para>
     <procedure xml:id="proc-configure-nginx">
       <title>Setting up nginx HTTP server</title>
@@ -105,12 +105,6 @@ http {
         # Expose TFTP boot directory for HTTP boot
         location /boot {
             alias      /srv/tftpboot/boot;
-            autoindex  on;
-        }
-
-        # Installation repositories are served directly from
-        # /srv/www/htdocs/install through the location / block above
-        location /install {
             autoindex  on;
         }
     }
@@ -260,7 +254,7 @@ EOF
            <command>setsebool -P httpd_serve_cobbler_files=1</command>. Run
            <command>ausearch -m avc -ts recent</command> to check for &selnx; denials; the
            command should produce no output once access is set up correctly. Do not work around
-           remaining denials with <command>audit2allow</command> &mdash; instead check the file
+           remaining denials with <command>audit2allow</command>. Instead, check the file
            context with <command>ls -lZ</command> or <command>matchpathcon</command> and confirm
            the required booleans are enabled.
           </para>
@@ -305,8 +299,8 @@ EOF
   <section xml:id="sles-pxe-server-configure-nginx-next-steps">
     <title>Next steps</title>
     <para>
-      With nginx configured for HTTP delivery, you can proceed to configure DHCP services for
-      directing PXE clients to the appropriate bootloaders and HTTP resources.
+      nginx is now ready to deliver boot files and installer content over HTTP. Next, configure
+      DHCP services to direct PXE clients to the appropriate boot loaders and HTTP resources.
     </para>
   </section>
 </topic>

--- a/tasks/sles-pxe-server-http-nginx.xml
+++ b/tasks/sles-pxe-server-http-nginx.xml
@@ -50,7 +50,7 @@
       </listitem>
       <listitem>
         <para>
-          Installation repositories available under <filename>/srv/install</filename>
+          Installation repositories available under <filename>/srv/www/htdocs/install</filename>
         </para>
       </listitem>
       <listitem>
@@ -108,9 +108,9 @@ http {
             autoindex  on;
         }
 
-        # Expose installation repositories and profiles
+        # Installation repositories are served directly from
+        # /srv/www/htdocs/install through the location / block above
         location /install {
-            alias      /srv/install;
             autoindex  on;
         }
     }
@@ -226,7 +226,7 @@ EOF
           <para>
             Check if the install directory exists:
           </para>
-<screen>&prompt.user;<command>ls -la /srv/install/</command></screen>
+<screen>&prompt.user;<command>ls -la /srv/www/htdocs/install/</command></screen>
         </step>
         <step>
           <para>
@@ -238,30 +238,31 @@ EOF
           <para>
             Create missing directories if needed:
           </para>
-<screen>&prompt.sudo;<command>mkdir -p /srv/install</command></screen>
+<screen>&prompt.sudo;<command>mkdir -p /srv/www/htdocs/install</command></screen>
         </step>
         <step>
           <para>
             Set appropriate permissions:
           </para>
-<screen>&prompt.sudo;<command>chmod -R 755 /srv/tftpboot/boot /srv/install</command></screen>
+<screen>&prompt.sudo;<command>chmod -R 755 /srv/tftpboot/boot /srv/www/htdocs/install</command></screen>
         </step>
         <step>
          <para>
-          If nginx still cannot serve files from <filename>/srv/install</filename>, the
-          directory may require additional &selnx; file context configuration. Run the
-          following commands to equivalence <filename>/srv/install</filename> to
-          <filename>/srv/www</filename> and restore the file context:
+          If nginx still cannot serve files from <filename>/srv/tftpboot/boot</filename>, restore
+          the &selnx; file context after placing or moving files into these directories:
          </para>
-<screen>&prompt.sudo;<command>semanage fcontext -e /srv/www -a /srv/install</command></screen>
-<screen>&prompt.sudo;<command>restorecon -RFv /srv/install/</command></screen>
+<screen>&prompt.sudo;<command>restorecon -Rv /srv/www/htdocs/install</command></screen>
+<screen>&prompt.sudo;<command>restorecon -Rv /srv/tftpboot/boot</command></screen>
          <note>
-          <title>&selnx; file context for <filename>/srv/install</filename></title>
+          <title>Verifying &selnx; access</title>
           <para>
-           This step may be required in addition to
-           <command>setsebool -P httpd_serve_cobbler_files=1</command>. Use
-           <command>ausearch -m avc -ts recent</command> to check for &selnx; denials
-           before and after applying these changes.
+           This step is needed in addition to
+           <command>setsebool -P httpd_serve_cobbler_files=1</command>. Run
+           <command>ausearch -m avc -ts recent</command> to check for &selnx; denials; the
+           command should produce no output once access is set up correctly. Do not work around
+           remaining denials with <command>audit2allow</command> &mdash; instead check the file
+           context with <command>ls -lZ</command> or <command>matchpathcon</command> and confirm
+           the required booleans are enabled.
           </para>
          </note>
        </step>

--- a/tasks/sles-pxe-server-install-components.xml
+++ b/tasks/sles-pxe-server-install-components.xml
@@ -65,7 +65,7 @@
           </listitem>
           <listitem>
             <para>
-              dnsmasq TFTP server: Delivers bootloader files, kernel and initrd over TFTP
+              dnsmasq TFTP server: Delivers boot loader files, kernel and initrd over TFTP
               during PXE boot.
             </para>
           </listitem>
@@ -111,7 +111,7 @@
       </listitem>
       <listitem>
         <para>
-          A TFTP server delivers the bootloader files, kernel and initrd over TFTP, while PXE boot
+          A TFTP server delivers the boot loader files, kernel and initrd over TFTP, while PXE boot
           with kea is provided by the <package>tftp</package> package and not required for HTTP Boot.
           If you are using <package>dnsmasq</package>, you do not need the <package>tftp</package>
           package.
@@ -136,13 +136,13 @@
             </listitem>
             <listitem>
               <para>
-                It is recommended for providing the <filename>squashfs.img</filename>. You can use
+                We recommend it for providing the <filename>squashfs.img</filename>. You can use
                 <literal>root=live:tftp://.../squashfs.img</literal> in the boot command line.
               </para>
             </listitem>
             <listitem>
               <para>
-                It is also recommended for providing RPMs to &agama; in the
+                We also recommend it for providing RPMs to &agama; in the
                 <literal>inst.install_url=http://.../install/</literal> boot command-line parameter
                 on a <filename>SLES-16.0-Full-*.inline.iso</filename>, along with installation
                 profiles and other files for unattended installation.
@@ -153,10 +153,10 @@
       </listitem>
       <listitem>
         <para>
-          The &grub; bootloader packages provide network boot for supported architectures and
+          The &grub; boot loader packages provide network boot for supported architectures and
           methods. For example, the &x86-64; architecture offers two methods for network boot:
           BIOS and UEFI. Additionally, UEFI generally supports PXE (TFTP) and HTTP Boot. Other
-          bootloaders, such as pxelinux, do not support UEFI and HTTP Boot.
+          boot loaders, such as pxelinux, do not support UEFI and HTTP Boot.
         </para>
       </listitem>
       <listitem>
@@ -197,7 +197,7 @@
       </listitem>
       <listitem>
         <para>
-          Access to the SLE module repositories for network services and bootloaders.
+          Access to the SLE module repositories for network services and boot loaders.
         </para>
       </listitem>
       <listitem>
@@ -222,7 +222,7 @@
       </step>
       <step>
         <para>
-          Run any of the following commands to install the essential packages for your approach:
+          Run any of the following commands to install the required packages for your approach:
         </para>
         <stepalternatives>
           <step>
@@ -265,13 +265,13 @@
             <para>
               For &aarch64; architecture:
             </para>
-<screen>&prompt.sudo;<command>zypper install grub2-aarch64-efi</command></screen>
+<screen>&prompt.sudo;<command>zypper install grub2-arm64-efi</command></screen>
           </step>
           <step>
             <para>
               For &ppc64le; architecture:
             </para>
-<screen>&prompt.sudo;<command>zypper install grub2-ppc64le-ieee1275</command></screen>
+<screen>&prompt.sudo;<command>zypper install grub2-powerpc-ieee1275</command></screen>
           </step>
         </stepalternatives>
         <note>

--- a/tasks/sles-pxe-server-netboot-directories-uefi-secure-boot.xml
+++ b/tasks/sles-pxe-server-netboot-directories-uefi-secure-boot.xml
@@ -80,41 +80,50 @@
       optionally configures &uefisecboot; support across multiple architectures.
     </para>
     <procedure>
-      <step>
+     <step>
+      <para>
+      Create a &grub; NetBoot directory structure.
+      </para>
+      <stepalternatives>
+       <step>
         <para>
-          Create a &grub; NetBoot directory structure.
+         For &x86-64;:
         </para>
-<screen>&prompt.sudo;<command>grub2-mknetdir --net-directory=/srv/tftpboot
---subdir=/boot/grub2</command></screen>
+<screen>&prompt.sudo;<command>grub2-mknetdir --net-directory=/srv/tftpboot --subdir=/boot/grub2 --directory=/usr/share/grub2/x86_64-efi</command></screen>
+<screen>&prompt.sudo;<command>grub2-mknetdir --net-directory=/srv/tftpboot --subdir=/boot/grub2 --directory=/usr/share/grub2/i386-pc</command></screen>
+       <para>
+        This creates the following directories:
+        <filename>/srv/tftpboot/boot/grub2/x86_64-efi</filename> and
+        <filename>/srv/tftpboot/boot/grub2/i386-pc</filename>.
+       </para>
+       </step>
+       <step>
         <para>
-          This creates architecture-specific directories:
+         For &aarch64;:
         </para>
-        <itemizedlist>
-          <listitem>
-            <para>
-              &x86-64;: <filename>/srv/tftpboot/boot/grub2/x86_64-efi</filename> and
-              <filename>/srv/tftpboot/boot/grub2/i386-pc </filename>
-            </para>
-          </listitem>
-          <listitem>
-            <para>
-              &aarch64;: <filename>/srv/tftpboot/boot/grub2/arm64-efi</filename>
-            </para>
-          </listitem>
-          <listitem>
-            <para>
-              &ppc64le;: <filename>/srv/tftpboot/boot/grub2/powerpc-ieee1275</filename>
-            </para>
-          </listitem>
-        </itemizedlist>
-        <warning>
-          <para>
-            Do not manually overwrite the <filename>grub.cfg</filename> file created by
-            <command>grub2-mknetdir</command>.
-          </para>
-        </warning>
-      </step>
-      <step>
+<screen>&prompt.sudo;<command>grub2-mknetdir --net-directory=/srv/tftpboot --subdir=/boot/grub2 --directory=/usr/share/grub2/arm64-efi</command></screen>
+        <para>
+         This creates the following directory: <filename>/srv/tftpboot/boot/grub2/arm64-efi</filename>.
+        </para>
+       </step>
+       <step>
+        <para>
+         For &ppc64le;:
+        </para>
+<screen>&prompt.sudo;<command>grub2-mknetdir --net-directory=/srv/tftpboot --subdir=/boot/grub2 --directory=/usr/share/grub2/powerpc-ieee1275</command></screen>
+        <para>
+         This creates the following directory: <filename>/srv/tftpboot/boot/grub2/powerpc-ieee1275</filename>.
+        </para>
+       </step>
+     </stepalternatives>
+      <warning>
+       <para>
+        Do not manually overwrite the <filename>grub.cfg</filename> file created by <command>grub2-mknetdir</command>.
+       </para>
+      </warning>
+     </step>
+
+     <step>
         <para>
           Copy other architecture-independent directories, such as <filename>fonts/</filename> and
           <filename>locale/</filename> that are available under the
@@ -168,8 +177,7 @@
           </step>
           <step>
             <para>
-              Use the <package>shim</package> package if you do not want to use the files from the
-              installation media ISO:
+             For &x86-64; and &aarch64; architectures, use the <package>shim</package> package if you do not want to use the files from the installation media ISO:
             </para>
             <substeps>
               <step>

--- a/tasks/sles-pxe-server-netboot-directories-uefi-secure-boot.xml
+++ b/tasks/sles-pxe-server-netboot-directories-uefi-secure-boot.xml
@@ -105,41 +105,50 @@
       optionally configures &uefisecboot; support across multiple architectures.
     </para>
     <procedure>
-      <step>
+     <step>
+      <para>
+      Create a &grub; NetBoot directory structure.
+      </para>
+      <stepalternatives>
+       <step>
         <para>
-          Create a &grub; NetBoot directory structure.
+         For &x86-64;:
         </para>
-<screen>&prompt.sudo;<command>grub2-mknetdir --net-directory=/srv/tftpboot
---subdir=/boot/grub2</command></screen>
+<screen>&prompt.sudo;<command>grub2-mknetdir --net-directory=/srv/tftpboot --subdir=/boot/grub2 --directory=/usr/share/grub2/x86_64-efi</command></screen>
+<screen>&prompt.sudo;<command>grub2-mknetdir --net-directory=/srv/tftpboot --subdir=/boot/grub2 --directory=/usr/share/grub2/i386-pc</command></screen>
+       <para>
+        This creates the following directories:
+        <filename>/srv/tftpboot/boot/grub2/x86_64-efi</filename> and
+        <filename>/srv/tftpboot/boot/grub2/i386-pc</filename>.
+       </para>
+       </step>
+       <step>
         <para>
-          This creates architecture-specific directories:
+         For &aarch64;:
         </para>
-        <itemizedlist>
-          <listitem>
-            <para>
-              &x86-64;: <filename>/srv/tftpboot/boot/grub2/x86_64-efi</filename> and
-              <filename>/srv/tftpboot/boot/grub2/i386-pc </filename>
-            </para>
-          </listitem>
-          <listitem>
-            <para>
-              &aarch64;: <filename>/srv/tftpboot/boot/grub2/arm64-efi</filename>
-            </para>
-          </listitem>
-          <listitem>
-            <para>
-              &ppc64le;: <filename>/srv/tftpboot/boot/grub2/powerpc-ieee1275</filename>
-            </para>
-          </listitem>
-        </itemizedlist>
-        <warning>
-          <para>
-            Do not manually overwrite the <filename>grub.cfg</filename> file created by
-            <command>grub2-mknetdir</command>.
-          </para>
-        </warning>
-      </step>
-      <step>
+<screen>&prompt.sudo;<command>grub2-mknetdir --net-directory=/srv/tftpboot --subdir=/boot/grub2 --directory=/usr/share/grub2/arm64-efi</command></screen>
+        <para>
+         This creates the following directory: <filename>/srv/tftpboot/boot/grub2/arm64-efi</filename>.
+        </para>
+       </step>
+       <step>
+        <para>
+         For &ppc64le;:
+        </para>
+<screen>&prompt.sudo;<command>grub2-mknetdir --net-directory=/srv/tftpboot --subdir=/boot/grub2 --directory=/usr/share/grub2/powerpc-ieee1275</command></screen>
+        <para>
+         This creates the following directory: <filename>/srv/tftpboot/boot/grub2/powerpc-ieee1275</filename>.
+        </para>
+       </step>
+     </stepalternatives>
+      <warning>
+       <para>
+        Do not manually overwrite the <filename>grub.cfg</filename> file created by <command>grub2-mknetdir</command>.
+       </para>
+      </warning>
+     </step>
+
+     <step>
         <para>
           Copy other architecture-independent directories, such as <filename>fonts/</filename> and
           <filename>locale/</filename> that are available under the
@@ -207,8 +216,7 @@
           </step>
           <step>
             <para>
-              Use the <package>shim</package> package if you do not want to use the files from the
-              installation media ISO:
+             For &x86-64; and &aarch64; architectures, use the <package>shim</package> package if you do not want to use the files from the installation media ISO:
             </para>
             <substeps>
               <step>

--- a/tasks/sles-pxe-server-netboot-directories-uefi-secure-boot.xml
+++ b/tasks/sles-pxe-server-netboot-directories-uefi-secure-boot.xml
@@ -30,7 +30,7 @@
         <command>grub2-mknetdir</command>, which generates architecture-specific directories for
         &x86-64; (UEFI and BIOS), &aarch64;, and &ppc64le; systems. For Secure Boot support,
         administrators must copy signed EFI files from installation media or use the
-        <package>shim</package> package to replace the default unsigned bootloader files.
+        <package>shim</package> package to replace the default unsigned boot loader files.
       </para>
     </abstract>
   </info>
@@ -43,7 +43,7 @@
       different platforms. For example, &x86-64; systems generate both UEFI
       (<filename>x86_64-efi</filename>) and legacy BIOS (<filename>i386-pc</filename>) directories,
       and &aarch64; systems create their UEFI directory in
-      <filename>arm64-efi</filename>. &ppc64le; systems (<filename>powerpc-ieee1275</filename>) supports secure boot too; the &grub; bootloader is in <filename>/boot/grub2/grub.elf</filename> on the ISOs.
+      <filename>arm64-efi</filename>. &ppc64le; systems (<filename>powerpc-ieee1275</filename>) supports secure boot too; the &grub; boot loader is in <filename>/boot/grub2/grub.elf</filename> on the ISOs.
     </para>
     <important>
      <para>
@@ -87,7 +87,7 @@
           Ensure that you have installed the following packages: <package>grub2</package>,
           <package>tftp</package>, and the &grub; platform package for every architecture you want
           to serve: <package>grub2-x86_64-efi</package>, <package>grub2-i386-pc</package>,
-          <package>grub2-aarch64-efi</package>, and <package>grub2-ppc64le-ieee1275</package>.
+          <package>grub2-arm64-efi</package>, and <package>grub2-powerpc-ieee1275</package>.
         </para>
       </listitem>
       <listitem>
@@ -173,8 +173,8 @@
                   <callout arearefs="copy-efi-files">
                     <para>
                       Replace <filename><replaceable>ARCH</replaceable>-efi</filename> with
-                      <filename>x86_64-efi</filename> or <filename>arm64-efi</filename>&mdash;the
-                      supported architectures for Secure Boot.
+                      <filename>x86_64-efi</filename> or <filename>arm64-efi</filename>, the
+                      architectures that support Secure Boot.
                     </para>
                   </callout>
                 </calloutlist>
@@ -200,7 +200,7 @@
               </step>
               <step>
                 <para>
-                  Copy the signed bootloader files for the necessary architecture:
+                  Copy the signed boot loader files for the necessary architecture:
                 </para>
                 <substeps>
                   <step>

--- a/tasks/sles-pxe-server-netboot-directories-uefi-secure-boot.xml
+++ b/tasks/sles-pxe-server-netboot-directories-uefi-secure-boot.xml
@@ -85,8 +85,9 @@
       <listitem>
         <para>
           Ensure that you have installed the following packages: <package>grub2</package>,
-          <package>tftp</package>, and any other architecture-specific &grub; package such as
-          <package>grub2-x86_64-efi</package> and <package>grub2-i386-pc</package>.
+          <package>tftp</package>, and the &grub; platform package for every architecture you want
+          to serve: <package>grub2-x86_64-efi</package>, <package>grub2-i386-pc</package>,
+          <package>grub2-aarch64-efi</package>, and <package>grub2-ppc64le-ieee1275</package>.
         </para>
       </listitem>
       <listitem>
@@ -107,54 +108,26 @@
     <procedure>
      <step>
       <para>
-      Create a &grub; NetBoot directory structure.
+       Create a &grub; NetBoot directory structure:
       </para>
-      <stepalternatives>
-       <step>
-        <para>
-         For &x86-64;:
-        </para>
-<screen>&prompt.sudo;<command>grub2-mknetdir --net-directory=/srv/tftpboot --subdir=/boot/grub2 --directory=/usr/share/grub2/x86_64-efi</command></screen>
-<screen>&prompt.sudo;<command>grub2-mknetdir --net-directory=/srv/tftpboot --subdir=/boot/grub2 --directory=/usr/share/grub2/i386-pc</command></screen>
-       <para>
-        This creates the following directories:
-        <filename>/srv/tftpboot/boot/grub2/x86_64-efi</filename> and
-        <filename>/srv/tftpboot/boot/grub2/i386-pc</filename>.
-       </para>
-       </step>
-       <step>
-        <para>
-         For &aarch64;:
-        </para>
-<screen>&prompt.sudo;<command>grub2-mknetdir --net-directory=/srv/tftpboot --subdir=/boot/grub2 --directory=/usr/share/grub2/arm64-efi</command></screen>
-        <para>
-         This creates the following directory: <filename>/srv/tftpboot/boot/grub2/arm64-efi</filename>.
-        </para>
-       </step>
-       <step>
-        <para>
-         For &ppc64le;:
-        </para>
-<screen>&prompt.sudo;<command>grub2-mknetdir --net-directory=/srv/tftpboot --subdir=/boot/grub2 --directory=/usr/share/grub2/powerpc-ieee1275</command></screen>
-        <para>
-         This creates the following directory: <filename>/srv/tftpboot/boot/grub2/powerpc-ieee1275</filename>.
-        </para>
-       </step>
-     </stepalternatives>
+<screen>&prompt.sudo;<command>grub2-mknetdir --net-directory=/srv/tftpboot --subdir=/boot/grub2</command></screen>
+      <para>
+       Without an explicit <option>--directory</option> option, <command>grub2-mknetdir</command>
+       generates a directory for every &grub; platform package installed on the PXE server, along
+       with the shared <filename>fonts/</filename> and <filename>locale/</filename> directories.
+       With the packages listed under <xref linkend="sles-pxe-server-netboot-directories-uefi-secure-boot-requirements"/>
+       installed, this creates
+       <filename>/srv/tftpboot/boot/grub2/x86_64-efi</filename>,
+       <filename>/srv/tftpboot/boot/grub2/i386-pc</filename>,
+       <filename>/srv/tftpboot/boot/grub2/arm64-efi</filename>, and
+       <filename>/srv/tftpboot/boot/grub2/powerpc-ieee1275</filename>.
+      </para>
       <warning>
        <para>
         Do not manually overwrite the <filename>grub.cfg</filename> file created by <command>grub2-mknetdir</command>.
        </para>
       </warning>
      </step>
-
-     <step>
-        <para>
-          Copy other architecture-independent directories, such as <filename>fonts/</filename> and
-          <filename>locale/</filename> that are available under the
-          <filename>/srv/tftpboot/boot/grub2/</filename> directory to the TFTP server.
-        </para>
-      </step>
       <step>
         <para>
           You can use the

--- a/tasks/sles-pxe-server-prepare-installer.xml
+++ b/tasks/sles-pxe-server-prepare-installer.xml
@@ -57,17 +57,17 @@
           <itemizedlist>
            <listitem>
             <para>
-             For &x86-64;: <filename>SLES-16.0-Online-x86_64-<replaceable>BUILD</replaceable>.install.iso</filename>
+             For &x86-64;: <filename>SLES-16.0-Online-x86_64-${<replaceable>BUILD</replaceable>}.install.iso</filename>
             </para>
            </listitem>
            <listitem>
             <para>
-             For &aarch64;: <filename>SLES-16.0-Online-aarch64-<replaceable>BUILD</replaceable>.install.iso</filename>
+             For &aarch64;: <filename>SLES-16.0-Online-aarch64-${<replaceable>BUILD</replaceable>}.install.iso</filename>
             </para>
            </listitem>
            <listitem>
             <para>
-             For &ppc64le;: <filename>SLES-16.0-Online-ppc64le-<replaceable>BUILD</replaceable>.install.iso</filename>
+             For &ppc64le;: <filename>SLES-16.0-Online-ppc64le-${<replaceable>BUILD</replaceable>}.install.iso</filename>
             </para>
            </listitem>
           </itemizedlist>
@@ -79,17 +79,17 @@
           <itemizedlist>
            <listitem>
             <para>
-             For &x86-64;: <filename>SLES-16.0-Full-x86_64-<replaceable>BUILD</replaceable>.install.iso</filename>
+             For &x86-64;: <filename>SLES-16.0-Full-x86_64-${<replaceable>BUILD</replaceable>}.install.iso</filename>
             </para>
            </listitem>
            <listitem>
             <para>
-             For &aarch64;: <filename>SLES-16.0-Full-aarch64-<replaceable>BUILD</replaceable>.install.iso</filename>
+             For &aarch64;: <filename>SLES-16.0-Full-aarch64-${<replaceable>BUILD</replaceable>}.install.iso</filename>
             </para>
            </listitem>
            <listitem>
             <para>
-             For &ppc64le;: <filename>SLES-16.0-Full-ppc64le-<replaceable>BUILD</replaceable>.install.iso</filename>
+             For &ppc64le;: <filename>SLES-16.0-Full-ppc64le-${<replaceable>BUILD</replaceable>}.install.iso</filename>
             </para>
            </listitem>
           </itemizedlist>
@@ -126,7 +126,7 @@
       <listitem>
         <para>
           Sufficient disk space under <filename>/srv/tftpboot</filename> and
-          <filename>/srv/install</filename> for your chosen installation method.
+          <filename>/srv/www/htdocs/install</filename> for your chosen installation method.
         </para>
       </listitem>
       <listitem>
@@ -135,6 +135,15 @@
         </para>
       </listitem>
     </itemizedlist>
+    <note>
+     <title>The <literal>${BUILD}</literal> placeholder</title>
+     <para>
+      The commands below reference the downloaded ISO file name through a
+      <literal>${BUILD}</literal> shell variable. Export it once with the build identifier from
+      your downloaded file, for example <command>export BUILD=Build135.5</command>, and every
+      command that follows can be copied and pasted exactly as shown.
+     </para>
+    </note>
   </section>
   <section xml:id="sles-pxe-server-prepare-installer-iso">
     <title>Preparing installer files from ISO images</title>
@@ -186,7 +195,7 @@
              For &x86-64;:
             </para>
 <screen>&prompt.sudo;<command>mount -oro,loop
-/srv/install/iso/SLES-16.0-Online-x86_64-<replaceable>BUILD</replaceable>.install.iso
+/srv/www/htdocs/install/iso/SLES-16.0-Online-x86_64-${<replaceable>BUILD</replaceable>}.install.iso
 /mnt</command></screen>
            </step>
            <step>
@@ -194,7 +203,7 @@
              For &aarch64;:
             </para>
 <screen>&prompt.sudo;<command>mount -oro,loop
-/srv/install/iso/SLES-16.0-Online-aarch64-<replaceable>BUILD</replaceable>.install.iso
+/srv/www/htdocs/install/iso/SLES-16.0-Online-aarch64-${<replaceable>BUILD</replaceable>}.install.iso
 /mnt</command></screen>
            </step>
            <step>
@@ -202,7 +211,7 @@
              For &ppc64le;:
             </para>
 <screen>&prompt.sudo;<command>mount -oro,loop
-/srv/install/iso/SLES-16.0-Online-ppc64le-<replaceable>BUILD</replaceable>.install.iso
+/srv/www/htdocs/install/iso/SLES-16.0-Online-ppc64le-${<replaceable>BUILD</replaceable>}.install.iso
 /mnt</command></screen>
            </step>
           </stepalternatives>
@@ -308,7 +317,7 @@
          <para>
           Create the directory for installation repository:
          </para>
-<screen>&prompt.sudo;<command>mkdir -p /srv/install/SLES-16.0</command></screen>
+<screen>&prompt.sudo;<command>mkdir -p /srv/www/htdocs/install/SLES-16.0</command></screen>
         </step>
         <step>
           <para>
@@ -320,7 +329,7 @@
              For &x86-64;:
             </para>
 <screen>&prompt.sudo;<command>mount -oro,loop
-/srv/install/iso/SLES-16.0-Full-x86_64-<replaceable>BUILD</replaceable>.install.iso
+/srv/www/htdocs/install/iso/SLES-16.0-Full-x86_64-${<replaceable>BUILD</replaceable>}.install.iso
 /mnt</command></screen>
            </step>
            <step>
@@ -328,7 +337,7 @@
              For &aarch64;:
             </para>
 <screen>&prompt.sudo;<command>mount -oro,loop
-/srv/install/iso/SLES-16.0-Full-aarch64-<replaceable>BUILD</replaceable>.install.iso
+/srv/www/htdocs/install/iso/SLES-16.0-Full-aarch64-${<replaceable>BUILD</replaceable>}.install.iso
 /mnt</command></screen>
            </step>
            <step>
@@ -336,7 +345,7 @@
              For &ppc64le;:
             </para>
 <screen>&prompt.sudo;<command>mount -oro,loop
-/srv/install/iso/SLES-16.0-Full-ppc64le-<replaceable>BUILD</replaceable>.install.iso
+/srv/www/htdocs/install/iso/SLES-16.0-Full-ppc64le-${<replaceable>BUILD</replaceable>}.install.iso
 /mnt</command></screen>
            </step>
           </stepalternatives>
@@ -442,21 +451,21 @@
              For &x86-64;:
             </para>
 <screen>&prompt.sudo;<command>rsync -avP /mnt/install/
-/srv/install/SLES-16.0/x86_64/</command></screen>
+/srv/www/htdocs/install/SLES-16.0/x86_64/</command></screen>
            </step>
            <step>
             <para>
              For &aarch64;:
             </para>
 <screen>&prompt.sudo;<command>rsync -avP /mnt/install/
-/srv/install/SLES-16.0/aarch64/</command></screen>
+/srv/www/htdocs/install/SLES-16.0/aarch64/</command></screen>
            </step>
            <step>
             <para>
              For &ppc64le;:
             </para>
 <screen>&prompt.sudo;<command>rsync -avP /mnt/install/
-/srv/install/SLES-16.0/ppc64le/</command></screen>
+/srv/www/htdocs/install/SLES-16.0/ppc64le/</command></screen>
            </step>
           </stepalternatives>
         </step>
@@ -606,7 +615,7 @@ tftpboot-agama-installer-SUSE_SLE_16-ppc64le</command></screen>
 │           │   └── squashfs.img <co xml:id="co-squashfs"/>
 │           ├── aarch64/
 │           └── ppc64le/
-/srv/install/
+/srv/www/htdocs/install/
 └── SLES-16.0/
     ├── x86_64/ <co xml:id="co-install-repo"/>
     ├── aarch64/

--- a/tasks/sles-pxe-server-prepare-installer.xml
+++ b/tasks/sles-pxe-server-prepare-installer.xml
@@ -30,7 +30,7 @@
     <title>Introduction</title>
     <para>
       &productname; &productnumber; provides installer files in multiple formats to support
-      different PXE boot scenarios. The &agama; installer requires three essential files: the
+      different PXE boot scenarios. The &agama; installer requires three files: the
       kernel image (<filename>linux</filename>), the initial RAM disk
       (<filename>initrd</filename>), and the compressed root file system
       (<filename>squashfs.img</filename>). These files must be extracted from the installation
@@ -57,17 +57,17 @@
           <itemizedlist>
            <listitem>
             <para>
-             For &x86-64;: <filename>SLES-16.0-Online-x86_64-${<replaceable>BUILD</replaceable>}.install.iso</filename>
+             For &x86-64;: <filename>SLES-16.0-Online-x86_64-<replaceable>BUILD</replaceable>.install.iso</filename>
             </para>
            </listitem>
            <listitem>
             <para>
-             For &aarch64;: <filename>SLES-16.0-Online-aarch64-${<replaceable>BUILD</replaceable>}.install.iso</filename>
+             For &aarch64;: <filename>SLES-16.0-Online-aarch64-<replaceable>BUILD</replaceable>.install.iso</filename>
             </para>
            </listitem>
            <listitem>
             <para>
-             For &ppc64le;: <filename>SLES-16.0-Online-ppc64le-${<replaceable>BUILD</replaceable>}.install.iso</filename>
+             For &ppc64le;: <filename>SLES-16.0-Online-ppc64le-<replaceable>BUILD</replaceable>.install.iso</filename>
             </para>
            </listitem>
           </itemizedlist>
@@ -79,17 +79,17 @@
           <itemizedlist>
            <listitem>
             <para>
-             For &x86-64;: <filename>SLES-16.0-Full-x86_64-${<replaceable>BUILD</replaceable>}.install.iso</filename>
+             For &x86-64;: <filename>SLES-16.0-Full-x86_64-<replaceable>BUILD</replaceable>.install.iso</filename>
             </para>
            </listitem>
            <listitem>
             <para>
-             For &aarch64;: <filename>SLES-16.0-Full-aarch64-${<replaceable>BUILD</replaceable>}.install.iso</filename>
+             For &aarch64;: <filename>SLES-16.0-Full-aarch64-<replaceable>BUILD</replaceable>.install.iso</filename>
             </para>
            </listitem>
            <listitem>
             <para>
-             For &ppc64le;: <filename>SLES-16.0-Full-ppc64le-${<replaceable>BUILD</replaceable>}.install.iso</filename>
+             For &ppc64le;: <filename>SLES-16.0-Full-ppc64le-<replaceable>BUILD</replaceable>.install.iso</filename>
             </para>
            </listitem>
           </itemizedlist>
@@ -138,10 +138,20 @@
     <note>
      <title>The <literal>${BUILD}</literal> placeholder</title>
      <para>
-      The commands below reference the downloaded ISO file name through a
-      <literal>${BUILD}</literal> shell variable. Export it once with the build identifier from
-      your downloaded file, for example <command>export BUILD=Build135.5</command>, and every
-      command that follows can be copied and pasted exactly as shown.
+      Both the file names above and the commands below reference the downloaded ISO through a
+      <literal>${BUILD}</literal> shell variable. Export it once with the build identifier of the
+      file you download, then every file name and command that follows can be copied and pasted
+      exactly as shown:
+     </para>
+<screen>&prompt.user;<command>export BUILD=Build135.5</command>
+&prompt.user;<command>wget https://.../SLES-16.0-Online-x86_64-${BUILD}.install.iso</command></screen>
+     <para>
+      The build identifier is whatever the download source offers for your version. On
+      <link xlink:href="https://www.suse.com/download/sles/"/> it is a release tag such as
+      <literal>GM</literal> (and later maintenance updates such as <literal>QU2</literal> or
+      <literal>QU3</literal>); on the internal build service it is a build number such as
+      <literal>Build135.5</literal>. It changes with every new build, so set it to match the file
+      you actually download.
      </para>
     </note>
   </section>
@@ -661,7 +671,7 @@ tftpboot-agama-installer-SUSE_SLE_16-ppc64le</command></screen>
       <title>Verification steps</title>
       <step>
         <para>
-          Check that essential files are present.
+          Check that the required files are present.
         </para>
         <stepalternatives>
          <step>
@@ -698,16 +708,16 @@ tftpboot-agama-installer-SUSE_SLE_16-ppc64le</command></screen>
     <important>
       <title>File accessibility</title>
       <para>
-        Ensure that all extracted files are readable by the TFTP and HTTP services. The files will
-        be accessed by PXE clients during the boot process, so proper permissions and service
-        configuration are essential for successful deployments.
+        Ensure that all extracted files are readable by the TFTP and HTTP services. PXE clients
+        access these files directly during boot, so incorrect permissions or service
+        configuration will cause boot failures.
       </para>
     </important>
   </section>
   <section xml:id="sles-pxe-server-prepare-installer-next">
     <title>Next steps</title>
     <para>
-      With the installer files properly prepared and organized, you can proceed to:
+      The installer files are now extracted and organized. Next:
     </para>
     <itemizedlist>
       <listitem>
@@ -722,7 +732,7 @@ tftpboot-agama-installer-SUSE_SLE_16-ppc64le</command></screen>
       </listitem>
       <listitem>
         <para>
-          Configure DHCP to direct PXE clients to the appropriate bootloaders
+          Configure DHCP to direct PXE clients to the appropriate boot loaders
         </para>
       </listitem>
     </itemizedlist>


### PR DESCRIPTION
### PR creator: Description

- Fixed missing `config` variable in `grub.cfg`
- Standardized menu entry names, added architecture-specific `grub2-mknetdir` commands with `--directory` option
- Clarified `shim` package scope to supported architectures
- Added note on HTTP loading of kernel and initrd, and added &selnx; file context fix for /srv/install.


### PR creator: Are there any relevant issues/feature requests?

* bsc#...https://bugzilla.suse.com/show_bug.cgi?id=1260343
* jsc#...https://jira.suse.com/browse/DOCTEAM-2206


### PR reviewer: Checklist for editorial review

Apart from the usual checks, please double-check also the following:

- [ ] do any new files fulfill the naming conventions specified in https://github.com/SUSE/doc-modular/blob/main/templates/README.md?
- [ ] article title/structure title: does it have the required length and does it use sentence style capitalization?
- [x] revhistory: is it up-to-date and does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-revhistory?  
- [x] backport: [16.0](https://github.com/SUSE/doc-modular/commit/26415f3ff821e2d64a1ac5748ad97c8ad9d7e4b6)
- [ ] metadata: does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-taglist-smartdocs?
