### PR TITLE
SLES 16.1: Specify CPU limits per architecture

### DIFF
--- a/references/alp-requirements.xml
+++ b/references/alp-requirements.xml
@@ -39,8 +39,19 @@
         <term>Maximum number of CPUs</term>
         <listitem>
           <para>
-            The maximum number of CPUs supported by software design is 8192.
+            The maximum number of CPUs supported by software design is:
           </para>
+          <itemizedlist>
+            <listitem>
+              <para>8192 on &x86-64; and &power;</para>
+            </listitem>
+            <listitem>
+              <para>768 on &aarch64;</para>
+            </listitem>
+            <listitem>
+              <para>512 on &zseries;</para>
+            </listitem>
+          </itemizedlist>
         </listitem>
       </varlistentry>
       <varlistentry>


### PR DESCRIPTION
### PR creator: Description

The hardware requirements were only naming the x86-64 CPU limit.
Correct the CPU limit for Arm and IBM Z, which is lower.

Note: SL Micro 6.0 and 6.1 had a lower limit (2048) for ppc64le; the numbers provided here have been verified back to SL Micro 6.2.

### PR creator: Are there any relevant issues/feature requests?

* jsc#PED-12858


### PR reviewer: Checklist for editorial review

Apart from the usual checks, please double-check also the following:

- [ ] do any new files fulfill the naming conventions specified in https://github.com/SUSE/doc-modular/blob/main/templates/README.md?
- [ ] article title/structure title: does it have the required length and does it use sentence style capitalization?
- [ ] revhistory: is it up-to-date and does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-revhistory?  
- [ ] metadata: does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-taglist-smartdocs?
