### PR TITLE
[SLE15SP6] NVIDIA-Jetson: Drop host OS from list of requirements

### DIFF
--- a/tasks/NVIDIA-Jetson-kmp.xml
+++ b/tasks/NVIDIA-Jetson-kmp.xml
@@ -52,14 +52,6 @@ in the assembly -->
           &nvidia; IGX &orin; based system
         </para>
       </listitem>
-      <listitem>
-        <para os="sles">
-          &sles; 15 SP6
-        </para>
-        <para os="slmicro">
-          &slem; 6.0 or &slm; 6.1
-        </para>
-      </listitem>
     </itemizedlist>
     <para condition="jetson">
       &nvidia; &jetson; &xavierreg; and earlier System-on-Module generations

--- a/tasks/NVIDIA-Jetson-libs.xml
+++ b/tasks/NVIDIA-Jetson-libs.xml
@@ -53,14 +53,6 @@ in the assembly -->
         </para>
       </listitem>
       <listitem>
-        <para os="sles">
-          &sles; 15 SP6
-        </para>
-        <para os="slmicro">
-          &slem; 6.0 or &slm; 6.1
-        </para>
-      </listitem>
-      <listitem>
         <para>
           Linux kernel modules for &nvidia; &orin; GPU
         </para>


### PR DESCRIPTION
### PR creator: Description

Backport #663 for SLES 15 SP6: Drop OS requirements


### PR creator: Are there any relevant issues/feature requests?

* bsc#1257270
* bsc#1264497


### PR reviewer: Checklist for editorial review

Apart from the usual checks, please double-check also the following:

- [ ] do any new files fulfill the naming conventions specified in https://github.com/SUSE/doc-modular/blob/main/templates/README.md?
- [ ] article title/structure title: does it have the required length and does it use sentence style capitalization?
- [ ] revhistory: is it up-to-date and does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-revhistory?  
- [ ] metadata: does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-taglist-smartdocs?
