### PR TITLE
[SLE16.0] NVIDIA-Jetson: Drop ROOTID

### DIFF
--- a/DC-Micro-arm-deployment-nvidia-jetson
+++ b/DC-Micro-arm-deployment-nvidia-jetson
@@ -2,8 +2,6 @@
 # This file can be edited downstream.
 
 MAIN="NVIDIA-Jetson.asm.xml"
-# Point to the ID of the <structure> of your assembly
-ROOTID="nvidia-jetson"
 SRC_DIR="articles"
 IMG_SRC_DIR="images"
 
@@ -11,6 +9,8 @@ PROFCONDITION="suse-product;jetson"
 #PROFCONDITION="suse-product;beta"
 #PROFCONDITION="community-project"
 PROFOS="slmicro"
+# Use the STRUCTID if there are several structures in one assembly file
+#STRUCTID="nvidia-jetson"
 
 STYLEASSEMBLY="/usr/share/xml/docbook/stylesheet/nwalsh5/current/assembly/assemble.xsl"
 

--- a/DC-SLES-arm-deployment-nvidia-jetson
+++ b/DC-SLES-arm-deployment-nvidia-jetson
@@ -2,8 +2,6 @@
 # This file can be edited downstream.
 
 MAIN="NVIDIA-Jetson.asm.xml"
-# Point to the ID of the <structure> of your assembly
-ROOTID="nvidia-jetson"
 SRC_DIR="articles"
 IMG_SRC_DIR="images"
 
@@ -11,6 +9,8 @@ PROFCONDITION="suse-product;jetson"
 #PROFCONDITION="suse-product;beta"
 #PROFCONDITION="community-project"
 PROFOS="sles"
+# Use the STRUCTID if there are several structures in one assembly file
+#STRUCTID="nvidia-jetson"
 
 STYLEASSEMBLY="/usr/share/xml/docbook/stylesheet/nwalsh5/current/assembly/assemble.xsl"
 


### PR DESCRIPTION
### PR creator: Description

The PDF links on the doc portal are currently broken for NVIDIA Jetson deployment docs.
@tomschr has identified the use of `ROOTID` in the DC files as cause.
`ROOTID` used to be in the original template but has been removed since (1ddb4a9921c4654afcfecc44ab6f6354d5493ebd).

Drop `ROOTID` from these DC files (and instead keep `STRUCTID` around).
This changes the file names from `nvidia-jetson_en.pdf` to `Micro-arm-deployment-nvidia-jetson_en.pdf` and `SLES-arm-deployment-nvidia-jetson_en.pdf`.

### PR creator: Are there any relevant issues/feature requests?

* bsc#1257270


### PR reviewer: Checklist for editorial review

Apart from the usual checks, please double-check also the following:

- [ ] do any new files fulfill the naming conventions specified in https://github.com/SUSE/doc-modular/blob/main/templates/README.md?
- [ ] article title/structure title: does it have the required length and does it use sentence style capitalization?
- [ ] revhistory: is it up-to-date and does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-revhistory?  
- [ ] metadata: does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-taglist-smartdocs?
