### PR TITLE
NVIDIA-Jetson: Add note about sle15-sp6 named repositories (bsc#1264536)

### DIFF
--- a/tasks/NVIDIA-Jetson-libs.xml
+++ b/tasks/NVIDIA-Jetson-libs.xml
@@ -86,6 +86,12 @@ in the assembly -->
 <screen>&prompt.sudo;<command>zypper addrepo https://repo.download.nvidia.com/jetson/sle15-sp6/jp6.1/ nvidia-jetpack</command></screen>
           </step>
         </stepalternatives>
+        <note>
+          <title>&nvidia; repository naming</title>
+          <para>The above repository addresses contain the directory
+            <filename class="directory">sle15-sp6</filename>.</para>
+          <para>That path is correct for newer operating systems, too.</para>
+        </note>
       </step>
       <step>
         <para>


### PR DESCRIPTION
### PR creator: Description

Users reported confusion about the NVIDIA repository URL having `sle15-sp6` in its path.

Add a note clarifying that this NVIDIA repository URL is indeed correct for any OS.

Applies to all maintenance branches other than `SLE15SP6`.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1264536


### PR reviewer: Checklist for editorial review

Apart from the usual checks, please double-check also the following:

- [ ] do any new files fulfill the naming conventions specified in https://github.com/SUSE/doc-modular/blob/main/templates/README.md?
- [ ] article title/structure title: does it have the required length and does it use sentence style capitalization?
- [ ] revhistory: is it up-to-date and does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-revhistory?  
- [ ] metadata: does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-taglist-smartdocs?
