### PR TITLE
Updated Virtualization glossary and acronyms

### DIFF
--- a/references/vt-acronyms.xml
+++ b/references/vt-acronyms.xml
@@ -78,7 +78,7 @@
         extensions to help bridge this performance gap. In 2006, both vendors
         introduced their first-generation hardware support for x86
         virtualization with AMD-Virtualization (AMD-V) and Intel® VT-x
-        technologies. Recently, Intel introduced its second generation of
+        technologies. Intel introduced its second generation of
         hardware support that incorporates MMU-virtualization, called Extended
         Page Tables (EPT). EPT-enabled systems can improve performance compared
         to using shadow paging for <xref linkend="gloss-vt-acronym-mmu"/>
@@ -88,14 +88,7 @@
       </para>
     </glossdef>
   </glossentry>
-  <glossentry xml:id="gloss-vt-acronym-hap"><glossterm>HAP</glossterm>
-    <glossdef>
-      <para><emphasis role="bold">High Assurance Platform</emphasis></para>
-      <para>A hardware and software security architecture designed to enforce 
-        strict isolation and improve workstation and network defense mechanisms.</para>
-    </glossdef>
-  </glossentry>
-  <glossentry xml:id="gloss-vt-acronym-hvm"><glossterm>HVM</glossterm>
+    <glossentry xml:id="gloss-vt-acronym-hvm"><glossterm>HVM</glossterm>
     <glossdef>
       <para><emphasis role="bold">Hardware Virtual Machine</emphasis></para>
       <para>A fully virtualized operating system instance running on hardware 

--- a/references/vt-acronyms.xml
+++ b/references/vt-acronyms.xml
@@ -2,441 +2,406 @@
 <!DOCTYPE topic
 [
 <!ENTITY % entities SYSTEM "../common/generic-entities.ent">
-    %entities;
+%entities;
 ]>
 
 <topic xml:id="vt-acronyms"
- role="reference" xml:lang="en"
- xmlns="http://docbook.org/ns/docbook" version="5.2"
- xmlns:its="http://www.w3.org/2005/11/its"
- xmlns:xi="http://www.w3.org/2001/XInclude"
- xmlns:xlink="http://www.w3.org/1999/xlink"
- xmlns:trans="http://docbook.org/ns/transclusion">
- <title>Acronyms</title>
- <info>
-      <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
-        <dm:bugtracker>
-        </dm:bugtracker>
-	<dm:translation>yes</dm:translation>
-      </dm:docmanager>
-    </info>
-    <glossentry xml:id="gloss-vt-acpi"><glossterm>ACPI</glossterm>
-  <glossdef>
-   <para>
-    Advanced Configuration and Power Interface (ACPI) specification provides
-    an open standard for device configuration and power management by the
-    operating system.
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-aer"><glossterm>AER</glossterm>
-  <glossdef>
-   <para>
-    Advanced Error Reporting
-   </para>
-   <para>
-    AER is a capability provided by the PCI Express specification which
-    allows for reporting of PCI errors and recovery from some of them.
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-apic"><glossterm>APIC</glossterm>
-  <glossdef>
-   <para>
-    Advanced Programmable Interrupt Controller (APIC) is a family of
-    interrupt controllers.
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-xmtoxl-vt-bdf"><glossterm>BDF</glossterm>
-  <glossdef>
-   <para>
-    Bus:Device:Function
-   </para>
-   <para>
-    Notation used to succinctly describe PCI and PCIe devices.
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-cg"><glossterm>CG</glossterm>
-  <glossdef>
-   <para>
-    Control Groups
-   </para>
-   <para>
-    Feature to limit, account and isolate resource usage (CPU, memory, disk
-    I/O, etc.).
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-xmtoxl-vt-edf"><glossterm>EDF</glossterm>
-  <glossdef>
-   <para>
-    Earliest Deadline First
-   </para>
-   <para>
-    This scheduler provides weighted CPU sharing in an intuitive way and
-    uses real-time algorithms to ensure time guarantees.
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-ept"><glossterm>EPT</glossterm>
-  <glossdef>
-   <para>
-    Extended Page Tables
-   </para>
-   <para>
-    Performance in a virtualized environment is close to that in a native
-    environment. Virtualization does create some overheads, however. These
-    come from the virtualization of the CPU, the
-    <xref linkend="gloss-vt-acronym-mmu"/>, and the I/O devices. In some
-    recent x86 processors AMD and Intel have begun to provide hardware
-    extensions to help bridge this performance gap. In 2006, both vendors
-    introduced their first generation hardware support for x86
-    virtualization with AMD-Virtualization (AMD-V) and Intel® VT-x
-    technologies. Recently Intel introduced its second generation of
-    hardware support that incorporates MMU-virtualization, called Extended
-    Page Tables (EPT). EPT-enabled systems can improve performance compared
-    to using shadow paging for <xref linkend="gloss-vt-acronym-mmu"/>
-    virtualization. EPT increases memory access latencies for a few
-    workloads. This cost can be reduced by effectively using large pages in
-    the guest and the hypervisor.
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-hap"><glossterm>HAP</glossterm>
-  <glossdef>
-   <para>
-    High Assurance Platform
-   </para>
-   <para>
-    HAP combines hardware and software technologies to improve workstation
-    and network security.
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-hvm"><glossterm>HVM</glossterm>
-  <glossdef>
-   <para>
-    Hardware Virtual Machine.
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-iommu"><glossterm>IOMMU</glossterm>
-  <glossdef>
-   <para>
-    Input/Output Memory Management Unit
-   </para>
-   <para>
-    IOMMU (AMD* technology) is a memory management unit
-    (<xref linkend="gloss-vt-acronym-mmu"/>) that connects a direct memory
-    access-capable (DMA-capable) I/O bus to the main memory.
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-ksm"><glossterm>KSM</glossterm>
-  <glossdef>
-   <para>
-    Kernel Same Page Merging
-   </para>
-   <para>
-    KSM allows for automatic sharing of identical memory pages between
-    guests to save host memory. &kvm; is optimized to use KSM if enabled
-    on the &vmhost;.
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-mmu"><glossterm>MMU</glossterm>
-  <glossdef>
-   <para>
-    Memory Management Unit
-   </para>
-   <para>
-    is a computer hardware component responsible for handling accesses to
-    memory requested by the CPU. Its functions include translation of
-    virtual addresses to physical addresses (that is, virtual memory
-    management), memory protection, cache control, bus arbitration and in
-    simpler computer architectures (especially 8-bit systems) bank
-    switching.
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-pae"><glossterm>PAE</glossterm>
-  <glossdef>
-   <para>
-    Physical Address Extension
-   </para>
-   <para>
-    32-bit x86 operating systems use Physical Address Extension (PAE) mode
-    to enable addressing of more than 4 GB of physical memory. In PAE mode,
-    page table entries (PTEs) are 64 bits in size.
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-pcid"><glossterm>PCID</glossterm>
-  <glossdef>
-   <para>
-    Process-context identifiers
-   </para>
-   <para>
-    These are a facility by which a logical processor may cache information
-    for multiple linear-address spaces so that the processor may retain
-    cached information when software switches to a different linear address
-    space. INVPCID instruction is used for fine-grained
-    <xref linkend="gloss-vt-acronym-tlb"/> flush, which is benefit for
-    kernel.
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-pcie"><glossterm>PCIe</glossterm>
-  <glossdef>
-   <para>
-    Peripheral Component Interconnect Express
-   </para>
-   <para>
-    PCIe was designed to replace older PCI, PCI-X and AGP bus standards.
-    PCIe has numerous improvements including a higher maximum system bus
-    throughput, a lower I/O pin count and smaller physical footprint.
-    Moreover it also has a more detailed error detection and reporting
-    mechanism (<xref linkend="gloss-vt-acronym-aer"/>), and a native
-    hotplug functionality. It is also backward compatible with PCI.
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-pse-pse36"><glossterm>PSE and PSE36</glossterm>
-  <glossdef>
-   <para>
-    Page Size Extended
-   </para>
-   <para>
-    PSE refers to a feature of x86 processors that allows for pages larger
-    than the traditional 4 KiB size. PSE-36 capability offers 4 more bits,
-    in addition to the normal 10 bits, which are used inside a page
-    directory entry pointing to a large page. This allows a large page to be
-    located in 36-bit address space.
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-pt"><glossterm>PT</glossterm>
-  <glossdef>
-   <para>
-    Page Table
-   </para>
-   <para>
-    A page table is the data structure used by a virtual memory system in a
-    computer operating system to store the mapping between virtual addresses
-    and physical addresses. Virtual addresses are those unique to the
-    accessing process. Physical addresses are those unique to the hardware
-    (RAM).
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-qxl"><glossterm>QXL</glossterm>
-  <glossdef>
-   <para>
-    QXL is a cirrus VGA framebuffer (8M) driver for virtualized environment.
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-rvi-npt"><glossterm>RVI or NPT</glossterm>
-  <glossdef>
-   <para>
-    Rapid Virtualization Indexing, Nested Page Tables
-   </para>
-   <para>
-    An AMD second generation hardware-assisted virtualization technology for
-    the processor memory management unit
-    (<xref linkend="gloss-vt-acronym-mmu"/>).
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-sata"><glossterm>SATA</glossterm>
-  <glossdef>
-   <para>
-    Serial ATA
-   </para>
-   <para>
-    SATA is a computer bus interface that connects host bus adapters to mass
-    storage devices such as hard disks and optical drives.
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-seccomp2-based-sandboxing"><glossterm>Seccomp2-based sandboxing</glossterm>
-  <glossdef>
-   <para>
-    Sandboxed environment where only predetermined system calls are
-    permitted for added protection against malicious behavior.
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-spice"><glossterm>SPICE</glossterm>
-  <glossdef>
-   <para>
-    Simple Protocol for Independent Computing Environments
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-tcg"><glossterm>TCG</glossterm>
-  <glossdef>
-   <para>
-    Tiny Code Generator
-   </para>
-   <para>
-    Instructions are emulated rather than executed by the CPU.
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-thp"><glossterm>THP</glossterm>
-  <glossdef>
-   <para>
-    Transparent Huge Pages
-   </para>
-   <para>
-    This allows CPUs to address memory using pages larger than the default 4
-    KB. This helps reduce memory consumption and CPU cache usage. &kvm;
-    is optimized to use THP (via madvise and opportunistic methods) if
-    enabled on the &vmhost;.
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-tlb"><glossterm>TLB</glossterm>
-  <glossdef>
-   <para>
-    Translation Lookaside Buffer
-   </para>
-   <para>
-    TLB is a cache that memory management hardware uses to improve virtual
-    address translation speed. All current desktop, notebook, and server
-    processors use a TLB to map virtual and physical address spaces, and it
-    is nearly always present in any hardware that uses virtual memory.
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-vcpu"><glossterm>VCPU</glossterm>
-  <glossdef>
-   <para>
-    A scheduling entity, containing each state for virtualized CPU.
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-vdi"><glossterm>VDI</glossterm>
-  <glossdef>
-   <para>
-    Virtual Desktop Infrastructure
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-vfio"><glossterm>VFIO</glossterm>
-  <glossdef>
-   <para>
-    Since kernel v3.6; a new method of accessing PCI devices from user space
-    called VFIO.
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-vhs"><glossterm>VHS</glossterm>
-  <glossdef>
-   <para>
-    Virtualization Host Server
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-vmcs"><glossterm>VMCS</glossterm>
-  <glossdef>
-   <para>
-    Virtual Machine Control Structure
-   </para>
-   <para>
-    VMX non-root operation and VMX transitions are controlled by a data
-    structure called a virtual-machine control structure (VMCS). Access to
-    the VMCS is managed through a component of processor state called the
-    VMCS pointer (one per logical processor). The value of the VMCS pointer
-    is the 64-bit address of the VMCS. The VMCS pointer is read and written
-    using the instructions VMPTRST and VMPTRLD. The
-    <xref linkend="gloss-vt-acronym-hypervisor-vmm"/> configures a VMCS
-    using the VMREAD, VMWRITE, and VMCLEAR instructions. A
-    <xref linkend="gloss-vt-acronym-hypervisor-vmm"/> could use a different
-    VMCS for each virtual machine that it supports. For a virtual machine
-    with multiple logical processors (virtual processors), the
-    <xref linkend="gloss-vt-acronym-hypervisor-vmm"/> could use a different
-    VMCS for each virtual processor.
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-vmdq"><glossterm>VMDq</glossterm>
-  <glossdef>
-   <para>
-    Virtual Machine Device Queue
-   </para>
-   <para>
-    Multi-queue network adapters exist which support multiple VMs at the
-    hardware level, having separate packet queues associated to the
-    different hosted VMs (by means of the IP addresses of the VMs).
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-hypervisor-vmm"><glossterm>VMM</glossterm>
-  <glossdef>
-   <para>
-    Virtual Machine Monitor (Hypervisor)
-   </para>
-   <para>
-    When the processor encounters an instruction or event of interest to the
-    Hypervisor (<xref linkend="gloss-vt-acronym-hypervisor-vmm"/>), it exits
-    from guest mode back to the VMM. The VMM emulates the instruction or
-    other event, at a fraction of native speed, and then returns to guest
-    mode. The transitions from guest mode to the VMM and back again are
-    high-latency operations, during which guest execution is completely
-    stalled.
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-vmroot"><glossterm>VM root</glossterm>
-  <glossdef>
-   <para>
-    <xref linkend="gloss-vt-acronym-hypervisor-vmm"/> will run in
-    <xref linkend="gloss-vt-acronym-vmx"/> root operation and guest software
-    will run in <xref linkend="gloss-vt-acronym-vmx"/> non-root operation.
-    Transitions between <xref linkend="gloss-vt-acronym-vmx"/> root
-    operation and <xref linkend="gloss-vt-acronym-vmx"/> non-root operation
-    are called <xref linkend="gloss-vt-acronym-vmx"/> transitions.
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-vmx"><glossterm>VMX</glossterm>
-  <glossdef>
-   <para>
-    Virtual Machine eXtensions
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-vpid"><glossterm>VPID</glossterm>
-  <glossdef>
-   <para>
-    New support for software control of
-    <xref linkend="gloss-vt-acronym-tlb"/> (VPID improves
-    <xref linkend="gloss-vt-acronym-tlb"/> performance with small
-    <xref linkend="gloss-vt-acronym-hypervisor-vmm"/> development effort).
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-vtd"><glossterm>VT-d</glossterm>
-  <glossdef>
-   <para>
-    Virtualization Technology for Directed I/O
-   </para>
-   <para>
-    Like <xref linkend="gloss-vt-acronym-iommu"/> for
-    <link xlink:href="https://software.intel.com/en-us/articles/intel-virtualization-technology-for-directed-io-vt-d-enhancing-intel-platforms-for-efficient-virtualization-of-io-devices">Intel*</link>.
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry xml:id="gloss-vt-acronym-vtpm"><glossterm>vTPM</glossterm>
-  <glossdef>
-   <para>
-    Component to establish end-to-end integrity for guests via Trusted
-    Computing.
-   </para>
-  </glossdef>
- </glossentry>
+       role="reference" xml:lang="en"
+       xmlns="http://docbook.org/ns/docbook" version="5.2"
+       xmlns:its="http://www.w3.org/2005/11/its"
+       xmlns:xi="http://www.w3.org/2001/XInclude"
+       xmlns:xlink="http://www.w3.org/1999/xlink"
+       xmlns:trans="http://docbook.org/ns/transclusion">
+  <title>Acronyms</title>
+  <info>
+    <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+      <dm:bugtracker>
+      </dm:bugtracker>
+      <dm:translation>yes</dm:translation>
+    </dm:docmanager>
+  </info>
+  <glossentry xml:id="gloss-vt-acpi"><glossterm>ACPI</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Advanced Configuration and Power Interface</emphasis></para>
+      <para>An open standard that provides uniform device configuration and power 
+        management capabilities directly to the operating system.</para>
+    </glossdef>
+    
+  </glossentry>
+  <glossentry xml:id="gloss-vt-acronym-aer"><glossterm>AER</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Advanced Error Reporting</emphasis></para>
+      <para>A capability within the PCI Express specification that enables 
+        advanced reporting, logging and recovery from PCI bus errors.</para>
+    </glossdef>
+    
+  </glossentry>
+  <glossentry xml:id="gloss-vt-apic"><glossterm>APIC</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Advanced Programmable Interrupt Controller</emphasis></para>
+      <para>An architecture of interrupt controllers designed to efficiently 
+        manage and route hardware interrupts across multiprocessing systems.</para>
+    </glossdef>
+  </glossentry>
+  <glossentry xml:id="gloss-xmtoxl-vt-bdf"><glossterm>BDF</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Bus:Device:Function</emphasis></para>
+      <para>A standard notation used to uniquely address and identify individual 
+        physical or virtual devices on a PCI/PCIe bus.</para>
+    </glossdef>
+  </glossentry>
+  <glossentry xml:id="gloss-vt-acronym-cg"><glossterm>CG</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Control Groups (cgroups)</emphasis></para>
+      <para>A Linux kernel feature used to limit, account for, isolate and 
+        prioritize the resource usage (such as CPU, memory and disk I/O) of 
+        collections of processes.</para>
+    </glossdef>
+  </glossentry>
+  <glossentry xml:id="gloss-xmtoxl-vt-edf"><glossterm>EDF</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Earliest Deadline First</emphasis></para>
+      <para>A dynamic priority scheduling algorithm that provides intuitive, 
+        real-time CPU resource sharing based on strict time guarantees.</para>
+    </glossdef>
+  </glossentry>
+  <glossentry xml:id="gloss-vt-acronym-ept"><glossterm>EPT</glossterm>
+    
+    <glossdef>
+      <para><emphasis role="bold">Extended Page Tables</emphasis></para>
+      <para>
+        Performance in a virtualized environment is close to that in a native
+        environment. However, virtualization does create overhead. It
+        comes from the virtualization of the CPU, the
+        <xref linkend="gloss-vt-acronym-mmu"/>, and the I/O devices. In some
+        recent x86 processors, AMD and Intel have begun to provide hardware
+        extensions to help bridge this performance gap. In 2006, both vendors
+        introduced their first-generation hardware support for x86
+        virtualization with AMD-Virtualization (AMD-V) and Intel® VT-x
+        technologies. Recently, Intel introduced its second generation of
+        hardware support that incorporates MMU-virtualization, called Extended
+        Page Tables (EPT). EPT-enabled systems can improve performance compared
+        to using shadow paging for <xref linkend="gloss-vt-acronym-mmu"/>
+        virtualization. EPT increases memory access latencies for a few
+        workloads. This cost can be reduced by effectively using large pages in
+        the guest and the hypervisor.
+      </para>
+    </glossdef>
+  </glossentry>
+  <glossentry xml:id="gloss-vt-acronym-hap"><glossterm>HAP</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">High Assurance Platform</emphasis></para>
+      <para>A hardware and software security architecture designed to enforce 
+        strict isolation and improve workstation and network defense mechanisms.</para>
+    </glossdef>
+  </glossentry>
+  <glossentry xml:id="gloss-vt-acronym-hvm"><glossterm>HVM</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Hardware Virtual Machine</emphasis></para>
+      <para>A fully virtualized operating system instance running on hardware 
+        that natively supports virtualization extensions (such as Intel VT-x or AMD-V).</para>
+    </glossdef>
+  </glossentry>
+  
+  <glossentry xml:id="gloss-vt-acronym-iommu"><glossterm>IOMMU</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Input/Output Memory Management Unit</emphasis></para>
+      <para>IOMMU (AMD* technology) is a memory management unit
+        (<xref linkend="gloss-vt-acronym-mmu"/>) that connects a direct memory
+        access-capable (DMA-capable) I/O bus to the main memory.
+      </para>
+    </glossdef>
+  </glossentry>
+  <glossentry xml:id="gloss-vt-acronym-ksm"><glossterm>KSM</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Kernel Same-page Merging</emphasis></para>
+      <para>A Linux kernel feature that allows for automatic sharing of 
+        identical memory pages between guests to save host memory. &kvm; is 
+        optimized to use KSM if enabled on the &vmhost;.</para>
+    </glossdef>
+  </glossentry>
+  
+  <glossentry xml:id="gloss-vt-acronym-mmu"><glossterm>MMU</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Memory Management Unit</emphasis></para>
+      <para>
+        A hardware component responsible for handling accesses to
+        memory requested by the CPU. Its functions include translation of
+        virtual addresses to physical addresses (that is, virtual memory
+        management), memory protection, cache control, bus arbitration and, in
+        simpler computer architectures (especially 8-bit systems), bank
+        switching.
+      </para>
+    </glossdef>
+    
+  </glossentry>
+  <glossentry xml:id="gloss-vt-acronym-pae"><glossterm>PAE</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Physical Address Extension</emphasis></para>
+      <para>A memory management feature that allows 32-bit x86 operating systems 
+        to address more than 4 GB of physical memory by expanding page table 
+        entries to 64 bits.</para>
+    </glossdef>
+    
+  </glossentry>
+  <glossentry xml:id="gloss-vt-acronym-pcid"><glossterm>PCID</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Process-Context Identifiers</emphasis></para>
+      <para>
+        A processor facility that caches information
+        for multiple linear-address spaces so that the processor may retain
+        cached information when software switches to a different linear address
+        space. The INVPCID instruction is used for fine-grained
+        <xref linkend="gloss-vt-acronym-tlb"/> flush, which benefits the kernel.
+      </para>
+    </glossdef>
+  </glossentry>
+  
+  <glossentry xml:id="gloss-vt-acronym-pcie"><glossterm>PCIe</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Peripheral Component Interconnect Express</emphasis></para>
+      <para>
+        A high-speed serial expansion bus standard designed to replace older 
+        PCI, PCI-X and AGP bus standards. PCIe has numerous improvements,
+        including a higher maximum system bus throughput, a lower I/O pin count 
+        and a smaller physical footprint.
+        Moreover, it also has a more detailed error detection and reporting
+        mechanism (<xref linkend="gloss-vt-acronym-aer"/>) and a native
+        hotplug functionality. It is also backward compatible with PCI.
+      </para>
+    </glossdef>
+  </glossentry>
+  
+  <glossentry xml:id="gloss-vt-acronym-pse-pse36"><glossterm>PSE / PSE36</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Page Size Extension / Page Size Extension 36-Bit</emphasis></para>
+      <para>
+        Hardware features in x86 processors that allow for pages larger
+        than the traditional 4 KiB size. PSE-36 capability offers 4 more bits,
+        in addition to the normal 10 bits, which are used inside a page
+        directory entry pointing to a large page. This allows a large page to be
+        located in a 36-bit address space.
+      </para>
+    </glossdef>
+  </glossentry>
+  
+  <glossentry xml:id="gloss-vt-acronym-pt"><glossterm>PT</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Page Table</emphasis></para>
+      <para>
+        The data structure used by a virtual memory system in a
+        computer operating system to store the mapping between virtual addresses
+        and physical addresses. Virtual addresses are those unique to the
+        accessing process. Physical addresses are those unique to the hardware
+        (RAM).
+      </para>
+    </glossdef>
+  </glossentry>
+  
+  <glossentry xml:id="gloss-vt-acronym-qxl"><glossterm>QXL</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">QXL Display Device</emphasis></para>
+      <para>
+        QXL is a cirrus VGA framebuffer (8M) driver for virtualized environment.
+      </para>
+    </glossdef>
+  </glossentry>
+  
+  <glossentry xml:id="gloss-vt-acronym-rvi-npt"><glossterm>RVI / NPT</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Rapid Virtualization Indexing / Nested Page Tables</emphasis></para>
+      <para>
+        AMD's second-generation hardware-assisted virtualization technology for
+        the processor memory management unit (<xref linkend="gloss-vt-acronym-mmu"/>).
+      </para>
+    </glossdef>
+  </glossentry>
+  
+  <glossentry xml:id="gloss-vt-acronym-sata"><glossterm>SATA</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Serial ATA</emphasis></para>
+      <para>
+        A computer bus interface that connects host bus adapters to mass
+        storage devices, such as hard disks and optical drives.
+      </para>
+    </glossdef>  
+  </glossentry>
+  
+  <glossentry xml:id="gloss-vt-acronym-seccomp2-based-sandboxing"><glossterm>Seccomp2-based sandboxing</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Secure Computing Mode sandboxing</emphasis></para>   
+      <para>
+        A sandboxed environment where only predetermined system calls are
+        permitted for added protection against malicious behavior.
+      </para>
+    </glossdef> 
+  </glossentry>
+  
+  <glossentry xml:id="gloss-vt-acronym-spice"><glossterm>SPICE</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Simple Protocol for Independent Computing Environments</emphasis></para>
+      <para>An open-source remote display protocol designed for virtual environments to deliver 
+        high-quality graphics and audio streaming over networks.</para>
+    </glossdef>
+  </glossentry>
+  
+  <glossentry xml:id="gloss-vt-acronym-tcg"><glossterm>TCG</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Tiny Code Generator</emphasis></para>
+      <para>The core component of the QEMU emulator that acts as a just-in-time compiler, 
+        translating target CPU instructions into host system architecture instructions.</para>
+    </glossdef>
+  </glossentry>
+  
+  <glossentry xml:id="gloss-vt-acronym-thp"><glossterm>THP</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Transparent Huge Pages</emphasis></para>
+      <para>
+        A Linux kernel feature that allows CPUs to address memory using pages 
+        larger than the default 4 KB. This helps reduce memory consumption and 
+        CPU cache usage. &kvm; is optimized to use THP (via madvise and opportunistic 
+        methods) if enabled on the &vmhost;.
+      </para>
+    </glossdef>   
+  </glossentry>
+  
+  <glossentry xml:id="gloss-vt-acronym-tlb"><glossterm>TLB</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Translation Lookaside Buffer</emphasis></para>
+      <para>
+        A hardware cache that memory management hardware uses to improve virtual
+        address translation speed. All current desktop, notebook and server
+        processors use a TLB to map virtual and physical address spaces, and it
+        is nearly always present in any hardware that uses virtual memory.
+      </para>
+    </glossdef>
+  </glossentry>
+  
+  <glossentry xml:id="gloss-vt-acronym-vcpu"><glossterm>VCPU</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Virtual Central Processing Unit</emphasis></para>
+      <para>A software-defined scheduling entity managed by a hypervisor that represents 
+        a single physical CPU core allocated to a virtual machine.</para>
+    </glossdef>
+  </glossentry>
+  
+  <glossentry xml:id="gloss-vt-acronym-vdi"><glossterm>VDI</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Virtual Desktop Infrastructure</emphasis></para>
+      <para>An IT architecture that hosts user desktop environments within virtual 
+        machines running on centralized data center servers.</para>
+    </glossdef>
+  </glossentry>
+  
+  <glossentry xml:id="gloss-vt-acronym-vfio"><glossterm>VFIO</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Virtual Function I/O</emphasis></para>
+      <para>A Linux kernel framework that provides secure, direct user-space 
+        access to PCI devices.</para>
+    </glossdef>
+  </glossentry>
+  
+  <glossentry xml:id="gloss-vt-acronym-vhs"><glossterm>VHS</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Virtualization Host Server</emphasis></para>
+      <para>A physical server hardware platform explicitly configured with a 
+        hypervisor to host, manage and run multiple virtual machines.</para>
+    </glossdef>
+  </glossentry>
+  
+  <glossentry xml:id="gloss-vt-acronym-vmcs"><glossterm>VMCS</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Virtual Machine Control Structure</emphasis></para>
+      <para>
+        VMX non-root operation and VMX transitions are controlled by a data
+        structure called a virtual-machine control structure (VMCS). Access to
+        the VMCS is managed through a component of processor state called the
+        VMCS pointer (one per logical processor). The value of the VMCS pointer
+        is the 64-bit address of the VMCS. The VMCS pointer is read and written
+        using the instructions VMPTRST and VMPTRLD. The
+        <xref linkend="gloss-vt-acronym-hypervisor-vmm"/> configures a VMCS
+        using the VMREAD, VMWRITE, and VMCLEAR instructions. A
+        <xref linkend="gloss-vt-acronym-hypervisor-vmm"/> could use a different
+        VMCS for each virtual machine that it supports. For a virtual machine
+        with multiple logical processors (virtual processors), the
+        <xref linkend="gloss-vt-acronym-hypervisor-vmm"/> could use a different
+        VMCS for each virtual processor.
+      </para>
+    </glossdef>
+  </glossentry>
+  
+  <glossentry xml:id="gloss-vt-acronym-vmdq"><glossterm>VMDq</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Virtual Machine Device Queues</emphasis></para>
+      <para>
+        Multi-queue network adapters that support multiple VMs at the
+        hardware level, having separate packet queues associated with the
+        different hosted VMs (by means of the IP addresses of the VMs).
+      </para>
+    </glossdef>
+  </glossentry>
+  
+  <glossentry xml:id="gloss-vt-acronym-hypervisor-vmm"><glossterm>VMM</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Virtual Machine Monitor (Hypervisor)</emphasis></para>
+      <para>
+        Software, firmware or hardware that creates, runs and manages
+        virtual machines, mediating access to the underlying physical resources. 
+      </para>
+    </glossdef>
+  </glossentry>
+  
+  <glossentry xml:id="gloss-vt-acronym-vmroot">
+    <glossterm>VMX Root / Non-Root Operation</glossterm>
+    <glossdef>
+      <para>
+        Processor execution modes introduced by
+        <xref linkend="gloss-vt-acronym-vmx"/>.
+        The <xref linkend="gloss-vt-acronym-hypervisor-vmm"/> runs in
+        VMX root operation, while guest software runs in VMX non-root
+        operation. Transitions between the two modes are called
+        VMX transitions.
+      </para>
+    </glossdef>
+  </glossentry>
+  
+  <glossentry xml:id="gloss-vt-acronym-vmx"><glossterm>VMX</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Virtual Machine Extensions</emphasis></para>
+      <para>Intel’s hardware-assisted virtualization technology architecture 
+        added to x86 processors to support native hypervisor execution.</para>
+    </glossdef>
+  </glossentry>
+  
+  <glossentry xml:id="gloss-vt-acronym-vpid"><glossterm>VPID</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Virtual Processor Identifiers</emphasis></para>
+      <para>New support for software control of
+        <xref linkend="gloss-vt-acronym-tlb"/> (VPID improves
+        <xref linkend="gloss-vt-acronym-tlb"/> performance with small
+        <xref linkend="gloss-vt-acronym-hypervisor-vmm"/> development effort).
+      </para>
+    </glossdef>
+  </glossentry>
+  
+  <glossentry xml:id="gloss-vt-acronym-vtd"><glossterm>VT-d</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Virtualization Technology for Directed I/O</emphasis></para>
+      <para>
+        <link xlink:href="https://software.intel.com/en-us/articles/intel-virtualization-technology-for-directed-io-vt-d-enhancing-intel-platforms-for-efficient-virtualization-of-io-devices">Intel's</link> 
+        hardware implementation of an <xref linkend="gloss-vt-acronym-iommu"/>, providing
+        device isolation and direct memory access (DMA) translation for virtualized environments.
+      </para>
+    </glossdef>
+  </glossentry>
+  
+  <glossentry xml:id="gloss-vt-acronym-vtpm"><glossterm>vTPM</glossterm>
+    <glossdef>
+      <para><emphasis role="bold">Virtual Trusted Platform Module</emphasis></para>
+      <para>
+        Component to establish end-to-end integrity for guests via Trusted
+        Computing.
+      </para>
+    </glossdef>
+  </glossentry>
 </topic>

--- a/references/vt-glossary.xml
+++ b/references/vt-glossary.xml
@@ -1,65 +1,37 @@
 <?xml version="1.0"?>
 <!DOCTYPE topic [
 <!ENTITY % entities SYSTEM "../common/generic-entities.ent">
-  %entities;
+%entities;
 ]>
 
 <topic xml:id="vt-glossary"
- role="reference" xml:lang="en"
- xmlns="http://docbook.org/ns/docbook" version="5.2"
- xmlns:its="http://www.w3.org/2005/11/its"
- xmlns:xi="http://www.w3.org/2001/XInclude"
- xmlns:xlink="http://www.w3.org/1999/xlink"
- xmlns:trans="http://docbook.org/ns/transclusion">
+       role="reference" xml:lang="en"
+       xmlns="http://docbook.org/ns/docbook" version="5.2"
+       xmlns:its="http://www.w3.org/2005/11/its"
+       xmlns:xi="http://www.w3.org/2001/XInclude"
+       xmlns:xlink="http://www.w3.org/1999/xlink"
+       xmlns:trans="http://docbook.org/ns/transclusion">
   <title>Glossary</title>
   <info>
     <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
       <dm:bugtracker/>
       <dm:translation>yes</dm:translation>
     </dm:docmanager>
-</info>
+  </info>
   <glossdiv xml:id="gloss-vt-general">
     <title>General</title>
-    <glossentry xml:id="gloss-vt-vmm"><glossterm>Virtual Machine Manager</glossterm>
+    <glossentry xml:id="gloss-vt-createvm"><glossterm>Create Virtual Machine Wizard</glossterm>
       <glossdef>
         <para>
-          A software program that provides a graphical user interface for
-          creating and managing virtual machines.
+          Virtual Machine Manager
+          provides a graphical interface to guide you through the steps to
+          create virtual machines. It can also be run in text mode by entering
+          <command>virt-install</command> at a command prompt in the host
+          environment.
         </para>
       </glossdef>
-    </glossentry>
-    <glossentry xml:id="gloss-vt-virtualized"><glossterm>Virtualized</glossterm>
-      <glossdef>
-        <para>
-          A guest operating system or application running on a virtual machine.
-        </para>
-      </glossdef>
-    </glossentry>
-    <glossentry xml:id="gloss-vt-vm"><glossterm>Virtual Machine</glossterm>
-      <glossdef>
-        <para>
-          A virtualized PC environment (VM) capable of hosting a guest
-          operating system and associated applications. Could be also called a
-          &vmguest;.
-        </para>
-      </glossdef>
-    </glossentry>
-    <glossentry xml:id="gloss-vt-vhs"><glossterm>VHS</glossterm>
-      <glossdef>
-        <para>
-          Virtualization Host Server
-        </para>
-        <para>
-          The physical computer running a &suse; virtualization platform
-          software. The virtualization environment consists of the hypervisor,
-          the host environment, virtual machines and associated tools, commands
-          and configuration files. Other commonly used terms include host, Host
-          Computer, Host Machine (HM), Virtual Server (VS), Virtual Machine
-          Host (VMH), and VM Host Server (VHS).
-        </para>
-      </glossdef>
-    </glossentry>
-    <glossentry xml:id="gloss-vt-hwassisted"><glossterm>hardware-assisted</glossterm>
+    </glossentry> 
+    <glossentry xml:id="gloss-vt-hwassisted"><glossterm>Hardware-assisted</glossterm>
       <glossdef>
         <para>
           Intel* and AMD* provide virtualization hardware-assisted technology.
@@ -71,17 +43,7 @@
         </para>
       </glossdef>
     </glossentry>
-    <glossentry xml:id="gloss-vt-createvm"><glossterm>Create Virtual Machine Wizard</glossterm>
-      <glossdef>
-        <para>
-          Virtual Machine Manager
-          provides a graphical interface to guide you through the steps to
-          create virtual machines. It can also be run in text mode by entering
-          <command>virt-install</command> at a command prompt in the host
-          environment.
-        </para>
-      </glossdef>
-    </glossentry>
+    
     <glossentry xml:id="gloss-vt-hostenv"><glossterm>Host Environment</glossterm>
       <glossdef>
         <para>
@@ -90,7 +52,7 @@
           environment and can also include a graphical desktop, such as &gnome;
           or IceWM. The host environment runs as a special type of virtual
           machine that has privileges to control and manage other virtual
-		machines.
+          machines.
         </para>
       </glossdef>
     </glossentry>
@@ -111,6 +73,18 @@
         </para>
       </glossdef>
     </glossentry>
+    <glossentry xml:id="gloss-vt-vhs"><glossterm>VHS</glossterm>
+      <glossdef>
+        <para>
+          A Virtualization Host Server (VHS) is the physical computer running 
+          &suse; virtualization platform software. The virtualization environment 
+          consists of the hypervisor, the host environment, virtual machines 
+          and associated tools, commands and configuration files. Other commonly 
+          used terms include host, Host Computer, Host Machine (HM), Virtual Server (VS), 
+          Virtual Machine Host (VMH) and VM Host Server (VHS).
+        </para>
+      </glossdef>
+    </glossentry>
     <glossentry xml:id="gloss-vt-virtfs"><glossterm>VirtFS</glossterm>
       <glossdef>
         <para>
@@ -120,17 +94,44 @@
         </para>
       </glossdef>
     </glossentry>
+    <glossentry xml:id="gloss-vt-virtualized"><glossterm>Virtualized</glossterm>
+      <glossdef>
+        <para>
+          The status or condition of a guest operating system or application 
+          executing within an isolated virtual machine environment.
+        </para>
+      </glossdef>
+    </glossentry>
+    <glossentry xml:id="gloss-vt-vm"><glossterm>Virtual Machine</glossterm>
+      <glossdef>
+        <para>
+          A software-defined computer environment (VM) capable of hosting an independent 
+          guest operating system and its associated applications. Also commonly referred 
+          to as a &vmguest;.
+        </para>
+      </glossdef>
+    </glossentry>
+    <glossentry xml:id="gloss-vt-vmm"><glossterm>Virtual Machine Manager</glossterm>
+      <glossdef>
+        <para>
+          A software program that provides a graphical user interface for
+          creating and managing virtual machines.
+        </para>
+      </glossdef>
+    </glossentry>
   </glossdiv>
+  
   <glossdiv xml:id="gloss-vt-cpu">
     <title>CPU</title>
     <glossentry xml:id="gloss-vt-cpu-capping"><glossterm>CPU capping</glossterm>
       <glossdef>
         <para>
-          Virtual CPU capping allows you to set vCPU capacity to 1–100 percent
-          of the physical CPU capacity.
+          The resource restriction process that limits a virtual CPU's allocation window to a 
+          defined percentage (from 1 to 100 percent) of available physical CPU capacity.
         </para>
       </glossdef>
     </glossentry>
+    
     <glossentry xml:id="gloss-vt-cpu-overcommit"><glossterm>CPU over-commitment</glossterm>
       <glossdef>
         <para>
@@ -152,13 +153,14 @@
     <glossentry xml:id="gloss-vt-cpu-pinning"><glossterm>CPU pinning</glossterm>
       <glossdef>
         <para>
-          Processor affinity, or CPU pinning enables the binding and unbinding
+          Also referred to as processor affinity; CPU pinning enables the binding and unbinding
           of a process or a thread to a central processing unit (CPU) or a
           range of CPUs.
         </para>
       </glossdef>
     </glossentry>
   </glossdiv>
+  
   <glossdiv xml:id="gloss-vt-network">
     <title>Network</title>
     <glossentry xml:id="gloss-vt-network-bridgenet"><glossterm>Bridged Networking</glossterm>
@@ -175,7 +177,7 @@
         <para>
           A type of network bridge that has no physical network device or
           virtual network device provided by the host. This lets virtual
-          machines communicate with other virtual machines on the same host but
+          machines communicate with other virtual machines on the same host, but
           not with the host or on an external network.
         </para>
       </glossdef>
@@ -234,6 +236,7 @@
       </glossdef>
     </glossentry>
   </glossdiv>
+  
   <glossdiv xml:id="gloss-vt-storage">
     <title>Storage</title>
     <glossentry xml:id="gloss-vt-storage-ahci"><glossterm>AHCI</glossterm>
@@ -248,7 +251,7 @@
     <glossentry xml:id="gloss-vt-storage-bd"><glossterm>Block Device</glossterm>
       <glossdef>
         <para>
-          Data storage devices, such as CD-ROM drives or disk drives, that move
+          Data storage components, such as CD-ROM drives or disk drives, that move
           data in the form of blocks. Partitions and volumes are also
           considered block devices.
         </para>
@@ -287,5 +290,5 @@
     </glossentry>
   </glossdiv>
   <!-- include acronyms 
-    <xi:include href="vt-acronyms.xml"/> -->
-</topic>
+       <xi:include href="vt-acronyms.xml"/> -->
+   </topic>


### PR DESCRIPTION
### PR creator: Description

Updated and structured VT acronym and glossary lists that are used in the Virtualization article assemblies:

```
gpu-passthru.asm.xml
virtualization-libvirt.asm.xml
virtualization-qemu.asm.xml
virtualization-spice-removal.asm.xml
virtualization.asm.xml
```


### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#...


### PR reviewer: Checklist for editorial review

Apart from the usual checks, please double-check also the following:

- [ ] do any new files fulfill the naming conventions specified in https://github.com/SUSE/doc-modular/blob/main/templates/README.md?
- [ ] article title/structure title: does it have the required length and does it use sentence style capitalization?
- [ ] revhistory: is it up-to-date and does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-revhistory?  
- [ ] metadata: does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-taglist-smartdocs?
