### PR TITLE
Add SELinux for SAP article

### DIFF
--- a/DC-SAP-SELinux-sap
+++ b/DC-SAP-SELinux-sap
@@ -1,0 +1,16 @@
+# This file originates from the project https://github.com/openSUSE/doc-kit
+# This file can be edited downstream.
+
+MAIN="SELinux-sap.asm.xml"
+SRC_DIR="articles"
+IMG_SRC_DIR="images"
+
+## Profiling
+PROFOS="sles4sap"
+#PROFCONDITION="16.0"
+#PROFARCH="x86_64;zseries;power;aarch64"
+
+DOCBOOK5_RNG_URI="urn:x-suse:rng:v2:geekodoc-flat"
+
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-SELinux-sap
+++ b/DC-SLES-SELinux-sap
@@ -1,0 +1,16 @@
+# This file originates from the project https://github.com/openSUSE/doc-kit
+# This file can be edited downstream.
+
+MAIN="SELinux-sap.asm.xml"
+SRC_DIR="articles"
+IMG_SRC_DIR="images"
+
+## Profiling
+PROFOS="sles"
+#PROFCONDITION="16.0"
+#PROFARCH="x86_64;zseries;power;aarch64"
+
+DOCBOOK5_RNG_URI="urn:x-suse:rng:v2:geekodoc-flat"
+
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/articles/SELinux-sap.asm.xml
+++ b/articles/SELinux-sap.asm.xml
@@ -29,8 +29,8 @@
   </resources>
   <!-- Tasks -->
   <resources>
-    <resource xml:id="_selinux-sap-relabeling-hana" href="../tasks/selinux-sap-relabeling-hana.xml">
-      <description>Relabeling the system for &hana;</description>
+    <resource xml:id="_selinux-sap-relabeling" href="../tasks/selinux-sap-relabeling.xml">
+      <description>Relabeling the system after &sap; software installations</description>
     </resource>
     <resource xml:id="_selinux-sap-resolving-access-violations" href="../tasks/selinux-sap-resolving-access-violations.xml">
       <description>Resolving &selnx; access violations</description>
@@ -116,7 +116,7 @@
         </abstract>
       </merge>
     </module>
-    <module resourceref="_selinux-sap-relabeling-hana" renderas="section">
+    <module resourceref="_selinux-sap-relabeling" renderas="section">
       <merge>
         <abstract>
           <para/>

--- a/articles/SELinux-sap.asm.xml
+++ b/articles/SELinux-sap.asm.xml
@@ -56,7 +56,7 @@
     <merge>
       <title>Using &selnx; with &sap; Workloads</title>
       <revhistory xml:id="rh-selinux-sap">
-        <revision><date>2026-07-17</date>
+        <revision><date>2026-07-21</date>
           <revdescription>
             <para>
               Initial version
@@ -73,7 +73,7 @@
       </meta>
       <meta name="title" its:translate="yes">Using &selnx; with &sap; Workloads</meta>
       <meta name="description" its:translate="yes">Learn about how &selnx; integrates with &sap; workloads such as &hana;</meta>
-      <meta name="social-descr" its:translate="yes">How &selnx; integrates with &sap; workloads such as &hana;</meta>
+      <meta name="social-descr" its:translate="yes">How &selnx; integrates with &sap; workloads like &hana;</meta>
       <!-- suitable categories has to be identical with the category selected in the docserv config -->
       <meta name="category" its:translate="no"><phrase>Security &amp; Compliance</phrase>
       </meta>
@@ -86,7 +86,8 @@
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
           <dm:component>Documentation</dm:component>
-          <dm:product>SUSE Linux Enterprise Server for SAP applications &productnumber;</dm:product>
+          <dm:product os="sles">SUSE Linux Enterprise Server &productnumber;</dm:product>
+          <dm:product os="sles4sap">SUSE Linux Enterprise Server for SAP applications &productnumber;</dm:product>
           <dm:assignee>eliska.romanova@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/articles/SELinux-sap.asm.xml
+++ b/articles/SELinux-sap.asm.xml
@@ -29,6 +29,9 @@
   </resources>
   <!-- Tasks -->
   <resources>
+    <resource xml:id="_selinux-sap-relabeling-hana" href="../tasks/selinux-sap-relabeling-hana.xml">
+      <description>Relabeling the system for &hana;</description>
+    </resource>
     <resource xml:id="_selinux-sap-resolving-access-violations" href="../tasks/selinux-sap-resolving-access-violations.xml">
       <description>Resolving &selnx; access violations</description>
     </resource>
@@ -107,6 +110,13 @@
       </merge>
     </module>
     <module resourceref="_selinux-sap-support" renderas="section">
+      <merge>
+        <abstract>
+          <para/>
+        </abstract>
+      </merge>
+    </module>
+    <module resourceref="_selinux-sap-relabeling-hana" renderas="section">
       <merge>
         <abstract>
           <para/>

--- a/articles/SELinux-sap.asm.xml
+++ b/articles/SELinux-sap.asm.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- This file originates from the project https://github.com/openSUSE/doc-kit -->
+<!-- This file can be edited downstream. -->
+<!DOCTYPE assembly
+[
+    <!ENTITY % entities SYSTEM "../common/generic-entities.ent">
+    %entities;
+]>
+<!-- refers to legacy doc: <add github link to legacy doc piece, if applicable> -->
+<!-- point back to this document with a similar comment added to your legacy doc piece -->
+<!-- refer to README.md for file and id naming conventions -->
+<assembly version="5.2" xml:lang="en"
+          xmlns:xlink="http://www.w3.org/1999/xlink"
+          xmlns:trans="http://docbook.org/ns/transclusion"
+          xmlns:its="http://www.w3.org/2005/11/its"
+          xmlns:xi="http://www.w3.org/2001/XInclude"
+          xmlns="http://docbook.org/ns/docbook">
+  <!-- resources section references all topic chunks used in the final article
+    -->
+  <!-- R E S O U R C E S -->
+  <!-- Concept files -->
+  <resources>
+    <resource xml:id="_selinux-sap-about" href="../concepts/selinux-sap-about.xml">
+      <description>How does &productnameshort; handle &selnx; for &sap; workloads?</description>
+    </resource>
+    <resource xml:id="_selinux-sap-support" href="../concepts/selinux-sap-support.xml">
+      <description>&selnx; support with &sap; software</description>
+    </resource>
+  </resources>
+  <!-- Tasks -->
+  <resources>
+    <resource xml:id="_selinux-sap-resolving-access-violations" href="../tasks/selinux-sap-resolving-access-violations.xml">
+      <description>Resolving &selnx; access violations</description>
+    </resource>
+    <resource xml:id="_selinux-sap-switching-to-enforcing-mode" href="../tasks/selinux-sap-switching-to-enforcing-mode.xml">
+      <description>Switching to enforcing mode</description>
+    </resource>
+    <resource xml:id="_selinux-sap-troubleshooting" href="../tasks/selinux-sap-troubleshooting.xml">
+      <description>Troubleshooting the &sap; &selnx; configuration</description>
+    </resource>
+  </resources>
+  <!-- Legal -->
+  <resources>
+    <resource href="../common/legal.xml" xml:id="_legal">
+      <description>Legal Notice</description>
+    </resource>
+    <resource href="../common/license_gfdl1.2.xml" xml:id="_gfdl">
+      <description>GNU Free Documentation License</description>
+    </resource>
+  </resources>
+  <!-- S T R U C T U R E -->
+  <structure renderas="article" xml:id="selinux-sap" xml:lang="en">
+    <merge>
+      <title>Using &selnx; with &sap; Workloads</title>
+      <revhistory xml:id="rh-selinux-sap">
+        <revision><date>2026-07-17</date>
+          <revdescription>
+            <para>
+              Initial version
+            </para>
+          </revdescription>
+        </revision>
+      </revhistory>
+      <!-- Maintainer -->
+      <meta name="maintainer" content="eliska.romanova@suse.com" its:translate="no"/>
+      <meta name="architecture"><phrase>&x86-64;</phrase><phrase>&power;</phrase><phrase>&ibm;</phrase><phrase>&aarch64;</phrase>
+      </meta>
+      <!-- enter one or more product names and version -->
+      <meta name="productname" its:translate="no"><productname version="&productnumber;" os="sles;sles4sap">&productname;</productname>
+      </meta>
+      <meta name="title" its:translate="yes">Using &selnx; with &sap; Workloads</meta>
+      <meta name="description" its:translate="yes">Learn about how &selnx; integrates with &sap; workloads such as &hana;</meta>
+      <meta name="social-descr" its:translate="yes">How &selnx; integrates with &sap; workloads such as &hana;</meta>
+      <!-- suitable categories has to be identical with the category selected in the docserv config -->
+      <meta name="category" its:translate="no"><phrase>Security &amp; Compliance</phrase>
+      </meta>
+      <!-- Determines "filter by task" filter value -->
+      <!-- either add link to list or list of tasks-->
+      <meta name="task" its:translate="no"><phrase>Security</phrase><phrase>Configuration</phrase><phrase>Deployment</phrase>
+      </meta>
+      <meta name="series" its:translate="no">Products &amp; Solutions</meta>
+      <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+        <dm:bugtracker>
+          <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
+          <dm:component>Documentation</dm:component>
+          <dm:product>SUSE Linux Enterprise Server for SAP Applications &productnumber;</dm:product>
+          <dm:assignee>eliska.romanova@suse.com</dm:assignee>
+        </dm:bugtracker>
+        <dm:translation>yes</dm:translation>
+      </dm:docmanager>
+      <abstract>
+        <para>
+          &productname; &productnumber; automatically configures &selnx; to support &sap; workloads
+          out of the box. The default configuration ensures a seamless deployment process and
+          allows administrators to safely validate security policies.
+        </para>
+      </abstract>
+    </merge>
+    <!-- pull in all the topic files you need -->
+    <!-- pick the appropriate type of include to match your needs -->
+    <!-- pull in a topic as is -->
+    <module resourceref="_selinux-sap-about" renderas="section">
+      <merge>
+        <abstract>
+          <para/>
+        </abstract>
+      </merge>
+    </module>
+    <module resourceref="_selinux-sap-support" renderas="section">
+      <merge>
+        <abstract>
+          <para/>
+        </abstract>
+      </merge>
+    </module>
+    <module resourceref="_selinux-sap-resolving-access-violations" renderas="section">
+      <merge>
+        <abstract>
+          <para/>
+        </abstract>
+      </merge>
+    </module>
+    <module resourceref="_selinux-sap-switching-to-enforcing-mode" renderas="section">
+      <merge>
+        <abstract>
+          <para/>
+        </abstract>
+      </merge>
+    </module>
+    <module resourceref="_selinux-sap-troubleshooting" renderas="section">
+      <merge>
+        <abstract>
+          <para/>
+        </abstract>
+      </merge>
+    </module>
+    <module resourceref="_legal"/>
+    <module resourceref="_gfdl">
+      <output renderas="appendix"/>
+    </module>
+  </structure>
+  <!-- TODO: second structure! -->
+</assembly>

--- a/articles/SELinux-sap.asm.xml
+++ b/articles/SELinux-sap.asm.xml
@@ -83,7 +83,7 @@
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
           <dm:component>Documentation</dm:component>
-          <dm:product>SUSE Linux Enterprise Server for SAP Applications &productnumber;</dm:product>
+          <dm:product>SUSE Linux Enterprise Server for SAP applications &productnumber;</dm:product>
           <dm:assignee>eliska.romanova@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/concepts/selinux-sap-about.xml
+++ b/concepts/selinux-sap-about.xml
@@ -53,8 +53,8 @@
     </listitem>
   </itemizedlist>
   <para>
-    This configuration ensures that the &sap; installation works out of the box without requiring
-    further manual adjustments.
+    This configuration ensures that the operating system is fully prepared for &sap; software
+    installations.
   </para>
   <para>
     For more information about &selnx;, see

--- a/concepts/selinux-sap-about.xml
+++ b/concepts/selinux-sap-about.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This file originates from the project https://github.com/openSUSE/doc-kit -->
+<!-- This file can be edited downstream. -->
+<!DOCTYPE topic
+[
+  <!ENTITY % entities SYSTEM "../common/generic-entities.ent">
+    %entities;
+]>
+<!-- refers to legacy doc: <add github link to legacy doc piece, if applicable> -->
+<!-- point back to this document with a similar comment added to your legacy doc piece -->
+<!-- refer to README.md for file and id naming conventions -->
+<!-- metadata is dealt with on the assembly level -->
+<topic xml:id="selinux-sap-about"
+ role="concept" xml:lang="en"
+ xmlns="http://docbook.org/ns/docbook" version="5.2"
+ xmlns:its="http://www.w3.org/2005/11/its"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink"
+ xmlns:trans="http://docbook.org/ns/transclusion">
+  <info>
+    <title>How does &productnameshort; handle &selnx; for &sap; workloads?</title>
+    <!-- can be changed via merge in the assembly -->
+    <!--add author's email address-->
+    <meta name="maintainer" content="eliska.romanova@suse.com" its:translate="no"/>
+    <abstract>
+      <!-- can be changed via merge in the assembly -->
+      <para>
+        This section describes how the operating system configures security settings for &sap;
+        workloads.
+      </para>
+    </abstract>
+  </info>
+  <para>
+    By default, &productname; &productnumber; enhances security by enabling &selnx; in enforcing
+    mode. When &sap; patterns are installed, the operating system automatically adjusts its
+    security policies:
+  </para>
+  <itemizedlist>
+    <listitem>
+      <para>
+        <emphasis role="bold">The &selnx; mode changes from enforcing to permissive.</emphasis> In
+        the permissive mode, &selnx; is active and access denial entries are logged, but no access
+        is denied. This configuration allows administrators to review their local setup and adjust
+        &selnx; policies before switching to enforcing mode.
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        <emphasis role="bold">&sap; software runs in an unconfined domain.</emphasis> Insert short
+        explanation here.
+      </para>
+    </listitem>
+  </itemizedlist>
+  <para>
+    This configuration ensures that the &sap; installation works out of the box without requiring
+    further manual adjustments.
+  </para>
+  <para>
+    For more information about &selnx;, see
+    <link os="sles4sap" xlink:href="https://documentation.suse.com/sles-sap/16.0/html/SAP-SELinux/"><citetitle>Understanding
+    &selnx;
+    Basics</citetitle></link><link os="sles" xlink:href="https://documentation.suse.com/sles/16.0/html/SLES-SELinux/"><citetitle>Understanding
+    &selnx; Basics</citetitle></link>.
+  </para>
+</topic>

--- a/concepts/selinux-sap-about.xml
+++ b/concepts/selinux-sap-about.xml
@@ -47,7 +47,7 @@
     <listitem>
       <para>
         <emphasis role="bold">&sap; software runs in an unconfined domain.</emphasis> Unconfined
-        domain means that there are no restrictions for the &sap; software. They can access system
+        domain means that there are no restrictions on the &sap; software. It can access system
         resources without &selnx; control.
       </para>
     </listitem>

--- a/concepts/selinux-sap-about.xml
+++ b/concepts/selinux-sap-about.xml
@@ -46,8 +46,9 @@
     </listitem>
     <listitem>
       <para>
-        <emphasis role="bold">&sap; software runs in an unconfined domain.</emphasis> Insert short
-        explanation here.
+        <emphasis role="bold">&sap; software runs in an unconfined domain.</emphasis> Unconfined
+        domain means that there are no restrictions for the &sap; software. They can access system
+        resources without &selnx; control.
       </para>
     </listitem>
   </itemizedlist>

--- a/concepts/selinux-sap-support.xml
+++ b/concepts/selinux-sap-support.xml
@@ -41,18 +41,16 @@
     <listitem>
       <para>
         &hana; is validated on &productnameshort; &productnumber; in both permissive and enforcing
-        modes.
+        modes. For more information, see
+        <link xlink:href="https://me.sap.com/notes/3577842">&sapnote; 3577842</link>.
       </para>
     </listitem>
     <listitem>
       <para>
         Other &sap; software is validated on &productnameshort; &productnumber; in permissive mode
-        only.
+        only. For more information, see
+        <link xlink:href="https://me.sap.com/notes/3565382">&sapnote; 3565382</link>.
       </para>
     </listitem>
   </itemizedlist>
-  <para>
-    For more information, see <link xlink:href="https://me.sap.com/notes/3577842">&sapnote;
-    3577842</link>.
-  </para>
 </topic>

--- a/concepts/selinux-sap-support.xml
+++ b/concepts/selinux-sap-support.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This file originates from the project https://github.com/openSUSE/doc-kit -->
+<!-- This file can be edited downstream. -->
+<!DOCTYPE topic
+[
+  <!ENTITY % entities SYSTEM "../common/generic-entities.ent">
+    %entities;
+]>
+<!-- refers to legacy doc: <add github link to legacy doc piece, if applicable> -->
+<!-- point back to this document with a similar comment added to your legacy doc piece -->
+<!-- refer to README.md for file and id naming conventions -->
+<!-- metadata is dealt with on the assembly level -->
+<topic xml:id="selinux-sap-support"
+ role="concept" xml:lang="en"
+ xmlns="http://docbook.org/ns/docbook" version="5.2"
+ xmlns:its="http://www.w3.org/2005/11/its"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink"
+ xmlns:trans="http://docbook.org/ns/transclusion">
+  <info>
+    <title>&selnx; support with &sap; software</title>
+    <!-- can be changed via merge in the assembly -->
+    <!--add author's email address-->
+    <meta name="maintainer" content="eliska.romanova@suse.com" its:translate="no"/>
+    <abstract>
+      <!-- can be changed via merge in the assembly -->
+      <para>
+        This section describes the support for &sap; software.
+      </para>
+    </abstract>
+  </info>
+  <para>
+    By default, after installing any &sap; pattern, &productname; is automatically configured with
+    &selnx; enabled in permissive mode and &sap; software in the unconfined domain. No further
+    action is required.
+  </para>
+  <para>
+    Validation states differ depending on the &sap; workload:
+  </para>
+  <itemizedlist>
+    <listitem>
+      <para>
+        &hana; is validated on &productnameshort; &productnumber; in both permissive and enforcing
+        modes.
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        Other &sap; software is validated on &productnameshort; &productnumber; in permissive mode
+        only.
+      </para>
+    </listitem>
+  </itemizedlist>
+  <para>
+    For more information, see <link xlink:href="https://me.sap.com/notes/3577842">&sapnote;
+    3577842</link>.
+  </para>
+</topic>

--- a/tasks/selinux-sap-relabeling-hana.xml
+++ b/tasks/selinux-sap-relabeling-hana.xml
@@ -10,47 +10,49 @@
 <!-- point back to this document with a similar comment added to your legacy doc piece -->
 <!-- refer to README.md for file and id naming conventions -->
 <!-- metadata is dealt with on the assembly level -->
-<topic xml:id="selinux-sap-support"
- role="concept" xml:lang="en"
+<topic xml:id="selinux-sap-relabeling-hana"
+ role="task" xml:lang="en"
  xmlns="http://docbook.org/ns/docbook" version="5.2"
  xmlns:its="http://www.w3.org/2005/11/its"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink"
  xmlns:trans="http://docbook.org/ns/transclusion">
   <info>
-    <title>&selnx; support with &sap; software</title>
-    <!-- can be changed via merge in the assembly -->
-    <!--add author's email address-->
+    <title>Relabeling the system for &hana;</title>
+    <!-- can be changed via merge
+      in the assembly -->
+    <!-- add author's e-mail -->
     <meta name="maintainer" content="eliska.romanova@suse.com" its:translate="no"/>
     <abstract>
       <!-- can be changed via merge in the assembly -->
       <para>
-        This section describes the support for &sap; software.
+        Learn how to relabel the system for &hana;.
       </para>
     </abstract>
   </info>
   <para>
-    By default, after installing any &sap; pattern, &productname; is automatically configured with
-    &selnx; enabled in permissive mode and &sap; software in the unconfined domain. No further
-    action is required before the installation.
+    After the installation of &hana; it is necessary to relabel the freshly installed software.
   </para>
   <para>
-    Validation states differ depending on the &sap; workload:
+    To relabel the system, choose one of the following methods:
   </para>
   <itemizedlist>
     <listitem>
       <para>
-        &hana; is validated on &productnameshort; &productnumber; in both permissive and enforcing
-        modes. For more information, see
-        <link xlink:href="https://me.sap.com/notes/3577842">&sapnote; 3577842</link>.
+        Relabel the system by using the <command>restorecon</command> command:
+      </para>
+<screen>&prompt.sudo;<command>restorecon -Rv /</command></screen>
+      <para>
+        Then restart all &sap; services so they run with the newly applied security contexts.
       </para>
     </listitem>
     <listitem>
       <para>
-        Other &sap; software is validated on &productnameshort; &productnumber; in permissive mode
-        only. For more information, see
-        <link xlink:href="https://me.sap.com/notes/3565382">&sapnote; 3565382</link>.
+        Create the <filename>.autorelabel</filename> file and reboot the system. The system will
+        automatically relabel all files during the next reboot:
       </para>
+<screen>&prompt.sudo;<command>touch /.autorelabel</command>
+&prompt.sudo;<command>reboot</command></screen>
     </listitem>
   </itemizedlist>
 </topic>

--- a/tasks/selinux-sap-relabeling.xml
+++ b/tasks/selinux-sap-relabeling.xml
@@ -10,7 +10,7 @@
 <!-- point back to this document with a similar comment added to your legacy doc piece -->
 <!-- refer to README.md for file and id naming conventions -->
 <!-- metadata is dealt with on the assembly level -->
-<topic xml:id="selinux-sap-relabeling-hana"
+<topic xml:id="selinux-sap-relabeling"
  role="task" xml:lang="en"
  xmlns="http://docbook.org/ns/docbook" version="5.2"
  xmlns:its="http://www.w3.org/2005/11/its"
@@ -18,7 +18,7 @@
  xmlns:xlink="http://www.w3.org/1999/xlink"
  xmlns:trans="http://docbook.org/ns/transclusion">
   <info>
-    <title>Relabeling the system for &hana;</title>
+    <title>Relabeling the system after &sap; software installations</title>
     <!-- can be changed via merge
       in the assembly -->
     <!-- add author's e-mail -->
@@ -26,12 +26,13 @@
     <abstract>
       <!-- can be changed via merge in the assembly -->
       <para>
-        Learn how to relabel the system for &hana;.
+        Learn how to relabel the system for &sap; software.
       </para>
     </abstract>
   </info>
   <para>
-    After the installation of &hana; it is necessary to relabel the freshly installed software.
+    After the installation of &sap; software it is necessary to relabel the freshly installed files
+    so they receive the correct security contexts.
   </para>
   <para>
     To relabel the system, choose one of the following methods:
@@ -39,17 +40,18 @@
   <itemizedlist>
     <listitem>
       <para>
-        Relabel the system by using the <command>restorecon</command> command:
+        Use the <command>restorecon</command> command:
       </para>
 <screen>&prompt.sudo;<command>restorecon -Rv /</command></screen>
       <para>
-        Then restart all &sap; services so they run with the newly applied security contexts.
+        Then restart all &sap; services.
       </para>
     </listitem>
     <listitem>
       <para>
-        Create the <filename>.autorelabel</filename> file and reboot the system. The system will
-        automatically relabel all files during the next reboot:
+        Create the <filename>.autorelabel</filename> file in the root (<filename>/</filename>)
+        partition and reboot the system. The system will automatically relabel all files during the
+        next reboot:
       </para>
 <screen>&prompt.sudo;<command>touch /.autorelabel</command>
 &prompt.sudo;<command>reboot</command></screen>

--- a/tasks/selinux-sap-relabeling.xml
+++ b/tasks/selinux-sap-relabeling.xml
@@ -31,8 +31,8 @@
     </abstract>
   </info>
   <para>
-    After the installation of &sap; software it is necessary to relabel the freshly installed files
-    so they receive the correct security contexts.
+    After installing &sap; software, relabel the freshly installed files so they receive the
+    correct security contexts.
   </para>
   <para>
     To relabel the system, choose one of the following methods:

--- a/tasks/selinux-sap-resolving-access-violations.xml
+++ b/tasks/selinux-sap-resolving-access-violations.xml
@@ -44,7 +44,7 @@
     Search for the AVC denials with the <command>ausearch</command> utility by running the
     following command:
   </para>
-<screen>&prompt.root;<command>ausearch -m AVC -ts boot</command>
+<screen>&prompt.sudo;<command>ausearch -m AVC -ts boot</command>
 type=AVC msg=audit(1784184190.493:34): avc:  denied  { name_connect } for
 pid=857 comm="erts_sched_1" dest=5432 scontext=system_u:system_r:init_t:s0
 tcontext=system_u:object_r:postgresql_port_t:s0 tclass=tcp_socket permissive=1

--- a/tasks/selinux-sap-resolving-access-violations.xml
+++ b/tasks/selinux-sap-resolving-access-violations.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This file originates from the project https://github.com/openSUSE/doc-kit -->
+<!-- This file can be edited downstream. -->
+<!DOCTYPE topic
+[
+  <!ENTITY % entities SYSTEM "../common/generic-entities.ent">
+    %entities;
+]>
+<!-- refers to legacy doc: <add github link to legacy doc piece, if applicable> -->
+<!-- point back to this document with a similar comment added to your legacy doc piece -->
+<!-- refer to README.md for file and id naming conventions -->
+<!-- metadata is dealt with on the assembly level -->
+<topic xml:id="selinux-sap-resolving-access-violations"
+ role="task" xml:lang="en"
+ xmlns="http://docbook.org/ns/docbook" version="5.2"
+ xmlns:its="http://www.w3.org/2005/11/its"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink"
+ xmlns:trans="http://docbook.org/ns/transclusion">
+  <info>
+    <title>Resolving &selnx; access violations</title>
+    <!-- can be changed via merge
+      in the assembly -->
+    <!-- add author's e-mail -->
+    <meta name="maintainer" content="eliska.romanova@suse.com" its:translate="no"/>
+    <abstract>
+      <!-- can be changed via merge in the assembly -->
+      <para>
+        Learn how to resolve &selnx; AVC denials.
+      </para>
+    </abstract>
+  </info>
+  <para>
+    When &selnx; denies permission to access an object, it creates an audit log using Access Vector
+    Cache (AVC) denials.
+  </para>
+  <para>
+    Because &productname; defaults to permissive mode after installing &sap; patterns,
+    administrators can identify and resolve potential security issues without disrupting the
+    system. If you are running &hana;, resolving these violations is a required step before you
+    transition the system to enforcing mode.
+  </para>
+  <para>
+    Search for the AVC denials with the <command>ausearch</command> utility by running the
+    following command:
+  </para>
+<screen>&prompt.root;<command>ausearch -m AVC -ts boot</command>
+type=AVC msg=audit(1784184190.493:34): avc:  denied  { name_connect } for
+pid=857 comm="erts_sched_1" dest=5432 scontext=system_u:system_r:init_t:s0
+tcontext=system_u:object_r:postgresql_port_t:s0 tclass=tcp_socket permissive=1
+</screen>
+  <para>
+    For more information on how to address the AVC denials, see
+    <link os="sles4sap" xlink:href="https://documentation.suse.com/sles-sap/16.0/html/SAP-SELinux/index.html#selinux-troubleshooting"><citetitle>&selnx;
+    troubleshooting</citetitle></link><link os="sles" xlink:href="https://documentation.suse.com/sles/16.0/html/SLES-SELinux/index.html#selinux-troubleshooting"><citetitle>&selnx;
+    troubleshooting</citetitle></link>.
+  </para>
+</topic>

--- a/tasks/selinux-sap-switching-to-enforcing-mode.xml
+++ b/tasks/selinux-sap-switching-to-enforcing-mode.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This file originates from the project https://github.com/openSUSE/doc-kit -->
+<!-- This file can be edited downstream. -->
+<!DOCTYPE topic
+[
+  <!ENTITY % entities SYSTEM "../common/generic-entities.ent">
+    %entities;
+]>
+<!-- refers to legacy doc: <add github link to legacy doc piece, if applicable> -->
+<!-- point back to this document with a similar comment added to your legacy doc piece -->
+<!-- refer to README.md for file and id naming conventions -->
+<!-- metadata is dealt with on the assembly level -->
+<topic xml:id="selinux-sap-switching-to-enforcing-mode"
+ role="task" xml:lang="en"
+ xmlns="http://docbook.org/ns/docbook" version="5.2"
+ xmlns:its="http://www.w3.org/2005/11/its"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink"
+ xmlns:trans="http://docbook.org/ns/transclusion">
+  <info>
+    <title>Switching to enforcing mode</title>
+    <!-- can be changed via merge
+      in the assembly -->
+    <!-- add author's e-mail -->
+    <meta name="maintainer" content="eliska.romanova@suse.com" its:translate="no"/>
+    <abstract>
+      <!-- can be changed via merge in the assembly -->
+      <para>
+        Learn how to switch to enforcing mode.
+      </para>
+    </abstract>
+  </info>
+  <para>
+    An administrator can switch to enforcing mode after the &hana; setup is tested and no access
+    violations occur.
+  </para>
+  <important>
+    <title>Enforcing mode for &hana; only</title>
+    <para>
+      Switching to enforcing mode is supported for &hana; workloads only. Other &sap; software must
+      remain in permissive mode.
+    </para>
+  </important>
+  <para>
+    To change to &selnx; enforcing mode, following the steps in
+    <link os="sles4sap" xlink:href="https://documentation.suse.com/sles-sap/16.0/html/SAP-SELinux/index.html#selinux-switching-modes"><citetitle>Changing
+    the &selnx;
+    mode</citetitle></link><link os="sles" xlink:href="https://documentation.suse.com/sles/16.0/html/SLES-SELinux/index.html#selinux-switching-modes"><citetitle>Changing
+    the &selnx; mode</citetitle></link>.
+  </para>
+  <para>
+    For more information, see <link xlink:href="https://me.sap.com/notes/3565382">&sapnote;
+    3565382</link>.
+  </para>
+</topic>

--- a/tasks/selinux-sap-switching-to-enforcing-mode.xml
+++ b/tasks/selinux-sap-switching-to-enforcing-mode.xml
@@ -42,7 +42,7 @@
     </para>
   </important>
   <para>
-    To change to &selnx; enforcing mode, following the steps in
+    To change to &selnx; enforcing mode, follow the steps described in
     <link os="sles4sap" xlink:href="https://documentation.suse.com/sles-sap/16.0/html/SAP-SELinux/index.html#selinux-switching-modes"><citetitle>Changing
     the &selnx;
     mode</citetitle></link><link os="sles" xlink:href="https://documentation.suse.com/sles/16.0/html/SLES-SELinux/index.html#selinux-switching-modes"><citetitle>Changing

--- a/tasks/selinux-sap-switching-to-enforcing-mode.xml
+++ b/tasks/selinux-sap-switching-to-enforcing-mode.xml
@@ -37,7 +37,7 @@
   <important>
     <title>Enforcing mode for &hana; only</title>
     <para>
-      Switching to enforcing mode is supported for &hana; workloads only. Other &sap; software must
+      Switching to enforcing mode is currently supported for &hana; workloads only. Other &sap; software must
       remain in permissive mode.
     </para>
   </important>
@@ -47,9 +47,5 @@
     the &selnx;
     mode</citetitle></link><link os="sles" xlink:href="https://documentation.suse.com/sles/16.0/html/SLES-SELinux/index.html#selinux-switching-modes"><citetitle>Changing
     the &selnx; mode</citetitle></link>.
-  </para>
-  <para>
-    For more information, see <link xlink:href="https://me.sap.com/notes/3565382">&sapnote;
-    3565382</link>.
   </para>
 </topic>

--- a/tasks/selinux-sap-troubleshooting.xml
+++ b/tasks/selinux-sap-troubleshooting.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This file originates from the project https://github.com/openSUSE/doc-kit -->
+<!-- This file can be edited downstream. -->
+<!DOCTYPE topic
+[
+  <!ENTITY % entities SYSTEM "../common/generic-entities.ent">
+    %entities;
+]>
+<!-- refers to legacy doc: <add github link to legacy doc piece, if applicable> -->
+<!-- point back to this document with a similar comment added to your legacy doc piece -->
+<!-- refer to README.md for file and id naming conventions -->
+<!-- metadata is dealt with on the assembly level -->
+<topic xml:id="selinux-sap-troubleshooting"
+ role="task" xml:lang="en"
+ xmlns="http://docbook.org/ns/docbook" version="5.2"
+ xmlns:its="http://www.w3.org/2005/11/its"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink"
+ xmlns:trans="http://docbook.org/ns/transclusion">
+  <info>
+    <title>Troubleshooting the &sap; &selnx; configuration</title>
+    <!-- can be changed via merge
+      in the assembly -->
+    <!-- add author's e-mail -->
+    <meta name="maintainer" content="eliska.romanova@suse.com" its:translate="no"/>
+    <abstract>
+      <!-- can be changed via merge in the assembly -->
+      <para>
+        Learn how to troubleshoot &selnx; for &sap;.
+      </para>
+    </abstract>
+  </info>
+  <para>
+    If you encounter issues with running &sap; software under &selnx;, first verify that the
+    <package>selinux-policy-sapenablement</package> package is installed. This package is
+    automatically installed as part of any &sap; pattern.
+  </para>
+<screen>&prompt.user;<command>rpm -q selinux-policy-sapenablement</command>
+selinux-policy-sapenablement-1-160000.2.3.noarch
+</screen>
+  <para>
+    For additional troubleshooting, see
+    <link os="sles4sap" xlink:href="https://documentation.suse.com/sles-sap/16.0/html/SAP-SELinux/index.html#selinux-troubleshooting"><citetitle>&selnx;
+    troubleshooting</citetitle></link><link os="sles" xlink:href="https://documentation.suse.com/sles/16.0/html/SLES-SELinux/index.html#selinux-troubleshooting"><citetitle>&selnx;
+    troubleshooting</citetitle></link>.
+  </para>
+</topic>


### PR DESCRIPTION
### PR creator: Description

Add new article for selinux for sap support. This applies to both SLES and SLES4SAP

Will be also cherry-picked to 16.0

### Previews
[first 2 commits]
SLES: [SLES-SELinux-sap_en.pdf](https://github.com/user-attachments/files/30085247/SLES-SELinux-sap_en.pdf)
SLES4SAP: [SAP-SELinux-sap_en.pdf](https://github.com/user-attachments/files/30085246/SAP-SELinux-sap_en.pdf)

[3-4 commit -latest changes]
SLES:  [SLES-SELinux-sap_en.pdf](https://github.com/user-attachments/files/30184314/SLES-SELinux-sap_en.pdf)
SLES4SAP: [SAP-SELinux-sap_en.pdf](https://github.com/user-attachments/files/30184310/SAP-SELinux-sap_en.pdf)


#### PR reviewer: Checklist for editorial review

Apart from the usual checks, please double-check also the following:

- [x] do any new files fulfill the naming conventions specified in https://github.com/SUSE/doc-modular/blob/main/templates/README.md?
- [x] article title/structure title: does it have the required length and does it use sentence style capitalization?
- [x] revhistory: is it up-to-date and does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-revhistory?  
- [x] metadata: does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-taglist-smartdocs?
