### PR TITLE
Update the 'Upgrading' article with SLES4SAP-specific information

### DIFF
--- a/references/sle16-upgrade-distribution-migration-system-configuration.xml
+++ b/references/sle16-upgrade-distribution-migration-system-configuration.xml
@@ -36,7 +36,7 @@
   <section>
     <title>Specify the upgrade target</title>
     <para>
-      The default upgrade target is &productnameshort; 16.0. This default target can be changed through the
+      The default upgrade target is <phrase os="sles;sleha">&slsa;</phrase><phrase os="sles4sap">&s4sa;</phrase> 16.0. This default target can be changed through the
       <literal>migration_product</literal> setting. The target must be specified with the triplet
       <literal>name/version/arch</literal> found in <filename>/etc/products.d/baseproduct</filename>
       of the target product, for example:

--- a/references/sle16-upgrade-distribution-migration-system-configuration.xml
+++ b/references/sle16-upgrade-distribution-migration-system-configuration.xml
@@ -36,7 +36,7 @@
   <section>
     <title>Specify the upgrade target</title>
     <para>
-      The default upgrade target is &slsa; 16.0. This default target can be changed through the
+      The default upgrade target is &productnameshort; 16.0. This default target can be changed through the
       <literal>migration_product</literal> setting. The target must be specified with the triplet
       <literal>name/version/arch</literal> found in <filename>/etc/products.d/baseproduct</filename>
       of the target product, for example:

--- a/tasks/sle16-upgrade-perform.xml
+++ b/tasks/sle16-upgrade-perform.xml
@@ -77,10 +77,10 @@
   </section>
   <section xml:id="task-sle16-upgrade-executing">
     <title>Upgrading &productname; 15 to &productnumber;</title>
-    <para>
+    <para os="sleha;sles">
       The distribution migration system can be invoked using two different methods:
     </para>
-    <itemizedlist>
+    <itemizedlist os="sleha;sles">
       <listitem>
         <para>
           Reboot after installing the <package>suse-migration-sle16-activation</package> package.
@@ -93,17 +93,24 @@
         </para>
       </listitem>
     </itemizedlist>
+    <para os="sles4sap">
+      The distribution migration system can be invoked by rebooting after installing the <package>suse-migration-sle16-activation</package> package.
+    </para>
     <para os="sleha;sles4sap">
       The distribution migration system upgrades both the base operating system and the &ha;
       cluster. Perform the upgrade on all the cluster nodes. The upgraded nodes won't be able to
       connect to non-upgraded nodes.
     </para>
-    <para>
+    <para os="sleha;sles">
       Depending on your architecture, perform the following steps to trigger the upgrade:
+    </para>
+    <para os="sles4sap">
+      Perform the following steps to trigger the upgrade:
     </para>
     <variablelist>
       <varlistentry>
-        <term>Use <command>reboot</command> on &x86-64;, &aarch64;, and &ppc64le;:</term>
+        <term os="sles">Use <command>reboot</command> on &x86-64;, &aarch64;, and &ppc64le;:</term>
+        <term os="sleha;sles4sap">Use <command>reboot</command> on &x86-64; and &ppc64le;:</term>
         <listitem>
           <para>
             After installing the <package>suse-migration-sle16-activation</package> package, start
@@ -113,12 +120,12 @@
 &prompt.sudo;<command>reboot</command></screen>
             <para>
               The <package>suse-migration-sle16-activation</package> package installs
-              <package>SLES16-Migration</package> as a dependency and modifies the bootloader
+              <package os="sleha;sles">SLES16-Migration</package><package os="sles4sap">SLES16-SAP_Migration</package> as a dependency and modifies the bootloader
               configuration to boot into the upgrade image.
             </para>
         </listitem>
       </varlistentry>
-      <varlistentry>
+      <varlistentry os="sleha;sles">
         <term>Use <command>run_migration</command> on &s390x;: </term>
         <listitem>
           <para>


### PR DESCRIPTION
#### PR creator: Description

The current "Upgrading to SUSE Linux Enterprise Server 16" article needs to be updated with SAP-specific information. For example, the name of the package, architectures, etc.


#### PR creator: Are there any relevant issues/feature requests?
* https://jira.suse.com/browse/DOCTEAM-2330

#### Preview:
<img width="1155" height="456" alt="image" src="https://github.com/user-attachments/assets/3b16f24b-5153-4216-a742-764a1d2967ad" />

#### Additional information:
- The PR does not change anything in SLES or HA (only removed one mention of unsupported architecture from HA, as per the discussion with @tahliar)
- The PR does not add new text regarding SLES4SAP, it only removes the information about unsupported architectures.
- With the chosen approach, the architectures can be easily added back for the os if they get supported in the future.
