### PR TITLE
Update toolchain support details for SLES 16.1 (jsc#PED-13336)

### DIFF
--- a/concepts/packages-lifecycle-toolchain.xml
+++ b/concepts/packages-lifecycle-toolchain.xml
@@ -61,16 +61,19 @@
         <para>
           Each even minor release of &suselinux; (the tick release) introduces a new major version of GCC as
           the default compiler. This GCC version is supported during the LTS for the minor version that
-          introduced it and also for the next &suselinux; minor version. For example, if GCC 17 is introduced
+          introduced it and also for the next &suselinux; minor version. For example, when GCC 17 is introduced
           in &suselinux; 16.2, it will be supported until the end of LTS for &suselinux; 16.3.
         </para>
       </listitem>
       <listitem>
         <para>
-          Each odd minor release of &suselinux; (the tock release) comes with a new non-default major
-          version of GCC. As this version is not the default one, you must explicitly
-          invoke the binaries <literal>gcc-x</literal>, <literal>g++-x</literal> and
-          <literal>gfortran-x</literal> to use it. These non-default versions are supported for 24 months.
+          Each odd minor release of &suselinux; (the tock release) comes with a new non-default
+          major version of GCC. As this version is not the default one, you must explicitly invoke
+          the binaries <literal>gcc-x</literal>, <literal>g++-x</literal> and
+          <literal>gfortran-x</literal> to use it. These non-default versions are supported for 24
+          months.  The non-default version specifically in SLES 16.1 is GCC 16 and can be invoked
+          with commands <literal>gcc-16</literal>, <literal>g++-16</literal> and
+          <literal>gfortran-16</literal>.
         </para>
       </listitem>
     </itemizedlist>
@@ -145,14 +148,14 @@
         with GNU extensions. 
       </para>
       <para>
-        For C++, the most recent supported version is ISO/IEC 14882:2017 (known as C++17) with GNU extensions.
+        For C++, when the default GCC 15 is used, the most recent supported version is ISO/IEC
+        14882:2017 (known as C++17) with GNU extensions.  When the non-default GCC 16 is used, the
+        most recent supported version is ISO/IEC 14882:2020 (often referred to as C++20) with GNU
+        extensions.
       </para>
       <para>
         For Fortran, we support versions up to Fortran 95 (ISO/IEC 1539:1997) with specific features of
         later standard versions as described in the manual.
-      </para>
-      <para>
-        &suse; also provides unsupported packages with compilers for Ada and Go (gcc-go).
       </para>
     </section>
   </section>

--- a/concepts/packages-lifecycle-toolchain.xml
+++ b/concepts/packages-lifecycle-toolchain.xml
@@ -67,13 +67,13 @@
       </listitem>
       <listitem>
         <para>
-          Each odd minor release of &suselinux; (the tock release) comes with a new non-default
-          major version of GCC. As this version is not the default one, you must explicitly invoke
+          Each odd minor release of &suselinux; (the tock release) includes a new non-default
+          major version of GCC. Because this version is not the default compiler, you must explicitly invoke
           the binaries <literal>gcc-x</literal>, <literal>g++-x</literal> and
           <literal>gfortran-x</literal> to use it. These non-default versions are supported for 24
-          months.  The non-default version specifically in SLES 16.1 is GCC 16 and can be invoked
-          with commands <literal>gcc-16</literal>, <literal>g++-16</literal> and
-          <literal>gfortran-16</literal>.
+          months. The non-default version provided specifically in &suselinux; 16.1 is GCC 16, 
+          which can be invoked with the commands <literal>gcc-16</literal>, 
+          <literal>g++-16</literal> and <literal>gfortran-16</literal>.
         </para>
       </listitem>
     </itemizedlist>
@@ -148,14 +148,14 @@
         with GNU extensions. 
       </para>
       <para>
-        For C++, when the default GCC 15 is used, the most recent supported version is ISO/IEC
-        14882:2017 (known as C++17) with GNU extensions.  When the non-default GCC 16 is used, the
-        most recent supported version is ISO/IEC 14882:2020 (often referred to as C++20) with GNU
+        For C++, when using the default GCC 15, the latest supported language standard is ISO/IEC
+        14882:2017 (known as C++17) with GNU extensions.  When using the non-default GCC 16, the
+        latest supported language standard is ISO/IEC 14882:2020 (often referred to as C++20) with GNU
         extensions.
       </para>
       <para>
-        For Fortran, we support versions up to Fortran 95 (ISO/IEC 1539:1997) with specific features of
-        later standard versions as described in the manual.
+For Fortran, we support versions up to Fortran 95 (ISO/IEC 1539:1997) with specific features from
+later standard versions as described in the manual.
       </para>
     </section>
   </section>


### PR DESCRIPTION
- Change "if GCC 17 is introduced" to "when GCC 17 is introduced" because we basically promise this will happen.

- Specify that the non-default compiler in SLES 16.1 will be GCC 16.

- Update the latest supported C++ standard with the non-default compiler. (This is the most important change.)

### PR creator: Description

Describe the overall goals of this pull request.


### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#...


### PR reviewer: Checklist for editorial review

Apart from the usual checks, please double-check also the following:

- [ ] do any new files fulfill the naming conventions specified in https://github.com/SUSE/doc-modular/blob/main/templates/README.md?
- [ ] article title/structure title: does it have the required length and does it use sentence style capitalization?
- [ ] revhistory: is it up-to-date and does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-revhistory?  
- [ ] metadata: does it follow the guidelines specified in https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-taglist-smartdocs?
